### PR TITLE
Minor correction to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y python3-pip
 
 RUN pip install pyserial paho-mqtt --break-system-packages
 
-COPY ./mctomqtt.py /opt
+COPY ./*.py /opt
 COPY ./config.ini /opt
 
 


### PR DESCRIPTION
Ensures all py files are available in the container to avoid a ModuleNotFoundError when the script imports local dependencies like `enums.py`

**Before**
```
$ docker logs -f 0e2b0bcf1b4d01fc7bf70bb01d9b53a5f8afca421a020619fc8c61a83f5653aa

Traceback (most recent call last):
  File "/opt/mctomqtt.py", line 13, in <module>
    from enums import AdvertFlags, PayloadType, PayloadVersion, RouteType, DeviceRole
ModuleNotFoundError: No module named 'enums'
Traceback (most recent call last):
  File "/opt/mctomqtt.py", line 13, in <module>
    from enums import AdvertFlags, PayloadType, PayloadVersion, RouteType, DeviceRole
ModuleNotFoundError: No module named 'enums'
Traceback (most recent call last):
  File "/opt/mctomqtt.py", line 13, in <module>
    from enums import AdvertFlags, PayloadType, PayloadVersion, RouteType, DeviceRole
ModuleNotFoundError: No module named 'enums'
Traceback (most recent call last):
  File "/opt/mctomqtt.py", line 13, in <module>
    from enums import AdvertFlags, PayloadType, PayloadVersion, RouteType, DeviceRole
ModuleNotFoundError: No module named 'enums'
Traceback (most recent call last):
  File "/opt/mctomqtt.py", line 13, in <module>
    from enums import AdvertFlags, PayloadType, PayloadVersion, RouteType, DeviceRole
ModuleNotFoundError: No module named 'enums'
```

**After**
```
$ docker logs -f 67a4391389780918fc01dad8fdda0c185f1dd1852535e916eb53a1983710b056

2025-09-07 19:37:50,674 - INFO - Configuration loaded successfully
2025-09-07 19:37:50,676 - INFO - Connected to /dev/serial/by-id/usb-Seeed_Studio_XIAO_nRF52840_F5421D092EEB1497-if00
2025-09-07 19:37:51,682 - INFO - Repeater name: <NAME>
2025-09-07 19:37:52,683 - INFO - Repeater pub key: <PUBKEY>
2025-09-07 19:37:53,186 - INFO - Using client ID: meshcore_<NAME>
2025-09-07 19:37:53,266 - INFO - Connected to MQTT broker
```
