### PR TITLE
Fix typo: Change 'Verison2' to 'Version2' in PayloadVersion enum

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -35,6 +35,6 @@ class PayloadType(Enum):
 
 class PayloadVersion(Enum):
     Version1 = 0x0
-    Verison2 = 0x1
+    Version2 = 0x1
     Version3 = 0x2
     Version4 = 0x3


### PR DESCRIPTION
I'm guessing this is unintended and `Version` is correct? 😅 