### PR TITLE
BLE mesh packet logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ python3 mctomqtt.py --config config.toml.example --debug    # enables DEBUG-leve
 
 **Python dependencies:** `pyserial`, `paho-mqtt` (install via pip or venv). Requires Python 3.11+ for `tomllib` stdlib.
 
+**Optional BLE dependency:** `bleak>=0.20` — required only when `[ble] enabled = true` in config. Install with `pip install bleak` or `pip install meshcoretomqtt[ble]`.
+
 **Optional dependency:** `meshcore-decoder` (Node.js CLI, `npm install -g @michaelhart/meshcore-decoder`) — required for JWT auth token generation/verification.
 
 **Docker:**
@@ -37,7 +39,8 @@ The runtime codebase is a `bridge/` Python package with a thin entry point (proj
 - **`mctomqtt.py`** — Thin entry point (~45 lines). Keeps `__version__`, argparse, logging setup. Creates `MeshCoreBridge(config, debug, version)` and calls `bridge.run()`.
 
 - **`bridge/`** — Python package containing all application logic, split into focused modules:
-  - **`serial_connection.py`** — `SerialConnection` ABC + `RealSerialConnection` (device I/O with internal locking) + `connect()` factory
+  - **`serial_connection.py`** — `SerialConnection` ABC + `RealSerialConnection` (device I/O with internal locking) + `connect()` factory (returns `BLESerialConnection` if `[ble] enabled = true`)
+  - **`ble_connection.py`** — `BLESerialConnection` (receives log lines via BLE Nordic UART Service using `bleak`; device identity values come from config)
   - **`auth_provider.py`** — `AuthProvider` ABC + `MeshCoreAuthProvider` (wraps `auth_token.py`)
   - **`broker_client.py`** — `BrokerClient` ABC + `PahoBrokerClient` (wraps paho-mqtt)
   - **`state.py`** — `BridgeState` shared mutable state container (all ~30 instance variables)
@@ -56,7 +59,7 @@ The runtime codebase is a `bridge/` Python package with a thin entry point (proj
 
 ### Testability
 
-Three ABC boundaries (`SerialConnection`, `AuthProvider`, `BrokerClient`) allow full control over external dependencies in tests. Fakes are in `tests/fakes.py`:
+Three ABC boundaries (`SerialConnection`, `AuthProvider`, `BrokerClient`) allow full control over external dependencies in tests. `BLESerialConnection` is tested via `__new__` construction (bypassing the BLE background thread) to exercise line-buffering and config-reading logic without hardware. Fakes are in `tests/fakes.py`:
 - `FakeSerialConnection` — returns canned device values
 - `FakeAuthProvider` — returns deterministic tokens, configurable verify/reject
 - `FakeBrokerClient` — records published messages for assertion

--- a/auth_token.py
+++ b/auth_token.py
@@ -236,12 +236,8 @@ def create_auth_token(public_key_hex: str, private_key_hex: str,
     Create a JWT-style auth token signed with the device's Ed25519 private key.
 
     Uses a pure-Python Ed25519 implementation (no external dependencies).
-    Falls back to the meshcore-decoder CLI on unexpected errors.
     """
-    try:
-        return _create_auth_token_python(public_key_hex, private_key_hex, expiry_seconds, **claims)
-    except Exception:
-        return _create_auth_token_cli(public_key_hex, private_key_hex, expiry_seconds, **claims)
+    return _create_auth_token_python(public_key_hex, private_key_hex, expiry_seconds, **claims)
 
 
 def verify_auth_token(token: str, expected_public_key_hex: str | None = None) -> dict[str, Any]:

--- a/auth_token.py
+++ b/auth_token.py
@@ -1,173 +1,276 @@
 #!/usr/bin/env python3
 """
 MeshCore Auth Token Generator
-Generates JWT-style authentication tokens for MQTT authentication
+
+Creates and verifies Ed25519-signed JWTs for MQTT authentication.
+Uses a pure-Python Ed25519 implementation for signing, and the
+`cryptography` package for verification when available; falls back to the
+`meshcore-decoder` Node.js CLI if not installed.
+
+Token format: standard JWT (header.payload.signature)
+  header:  {"alg":"Ed25519","typ":"JWT"}
+  payload: {"publicKey": "<hex>", "iat": <unix>, "exp": <unix>, ...claims}
+  sig:     raw Ed25519 signature over base64url(header).base64url(payload)
+           encoded as uppercase hex (not base64url)
+
+MeshCore private key format: 64 bytes = expanded Ed25519 key
+  bytes  0-31: SHA-512(seed)[0:32] with clamping — the scalar used for signing
+  bytes 32-63: SHA-512(seed)[32:64] — the nonce prefix
 """
 from __future__ import annotations
 
-import json
 import base64
-import hashlib
+import json
 import time
 import subprocess
 import sys
 from typing import Any
 
+
 def base64url_encode(data: bytes) -> str:
-    """Base64url encode without padding"""
+    """Base64url encode without padding."""
     return base64.urlsafe_b64encode(data).rstrip(b'=').decode('utf-8')
 
-def create_auth_token(public_key_hex: str, private_key_hex: str, expiry_seconds: int = 3600, **claims: Any) -> str:
+
+def base64url_decode(s: str) -> bytes:
+    """Base64url decode, adding padding as needed."""
+    padding = 4 - len(s) % 4
+    if padding != 4:
+        s += '=' * padding
+    return base64.urlsafe_b64decode(s)
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python Ed25519 signing with MeshCore expanded key format
+# ---------------------------------------------------------------------------
+
+def _ed25519_sign_expanded(expanded_key: bytes, public_key: bytes, message: bytes) -> bytes:
+    """Sign using MeshCore's 64-byte expanded Ed25519 private key.
+
+    expanded_key[0:32]: clamped scalar (used directly for signing)
+    expanded_key[32:64]: nonce prefix (hashed with message to generate r)
+
+    Uses only hashlib; no third-party dependencies required.
     """
-    Create a JWT-style auth token for MeshCore MQTT authentication
-    
-    Uses the meshcore-decoder CLI tool.
-    
-    Args:
-        public_key_hex: 32-byte public key in hex format
-        private_key_hex: 64-byte private key in hex format (MeshCore format)
-        expiry_seconds: Token expiry time in seconds (default 24 hours)
-        **claims: Additional JWT claims (e.g., audience="mqtt.example.com", sub="device-123")
-    
-    Returns:
-        JWT-style token string
-    """
+    import hashlib
+
+    P = 2**255 - 19
+    L = 2**252 + 27742317777372353535851937790883648493
+
+    def _sha512(*parts: bytes) -> bytes:
+        h = hashlib.sha512()
+        for p in parts:
+            h.update(p)
+        return h.digest()
+
+    def _inv(x: int) -> int:
+        return pow(x, P - 2, P)
+
+    d = -121665 * _inv(121666) % P
+
+    def _recover_x(y: int, sign: int) -> int:
+        y2 = y * y % P
+        x2 = (y2 - 1) * _inv(d * y2 + 1) % P
+        if x2 == 0:
+            return 0
+        x = pow(x2, (P + 3) // 8, P)
+        if (x * x - x2) % P != 0:
+            x = x * pow(2, (P - 1) // 4, P) % P
+        if x & 1 != sign:
+            x = P - x
+        return x
+
+    Gy = 4 * _inv(5) % P
+    Gx = _recover_x(Gy, 0)
+    G = (Gx, Gy, 1, Gx * Gy % P)  # Extended coordinates (X, Y, Z, T)
+
+    def _add(pt1: tuple, pt2: tuple) -> tuple:
+        x1, y1, z1, t1 = pt1
+        x2, y2, z2, t2 = pt2
+        a = (y1 - x1) * (y2 - x2) % P
+        b = (y1 + x1) * (y2 + x2) % P
+        c = t1 * 2 * d * t2 % P
+        e_val = z1 * 2 * z2 % P
+        e = b - a
+        f = e_val - c
+        g = e_val + c
+        h = b + a
+        return (e * f % P, g * h % P, f * g % P, e * h % P)
+
+    def _mul(s: int, pt: tuple) -> tuple:
+        q = (0, 1, 1, 0)  # neutral element
+        while s:
+            if s & 1:
+                q = _add(q, pt)
+            pt = _add(pt, pt)
+            s >>= 1
+        return q
+
+    def _encode(pt: tuple) -> bytes:
+        zi = _inv(pt[2])
+        x = pt[0] * zi % P
+        y = pt[1] * zi % P
+        b = bytearray(y.to_bytes(32, 'little'))
+        if x & 1:
+            b[31] |= 0x80
+        return bytes(b)
+
+    nonce_prefix = expanded_key[32:64]
+    scalar_a = int.from_bytes(expanded_key[0:32], 'little')
+    r = int.from_bytes(_sha512(nonce_prefix, message), 'little') % L
+    R = _encode(_mul(r, G))
+    k = int.from_bytes(_sha512(R, public_key, message), 'little') % L
+    S = (r + k * scalar_a) % L
+    return R + S.to_bytes(32, 'little')
+
+
+# ---------------------------------------------------------------------------
+# Python-native Ed25519 implementation
+# ---------------------------------------------------------------------------
+
+def _create_auth_token_python(public_key_hex: str, private_key_hex: str,
+                               expiry_seconds: int = 3600, **claims: Any) -> str:
+    now = int(time.time())
+    header_b64 = base64url_encode(json.dumps({"alg": "Ed25519", "typ": "JWT"}, separators=(',', ':')).encode())
+    payload_b64 = base64url_encode(json.dumps(
+        {"publicKey": public_key_hex.upper(), "iat": now, "exp": now + expiry_seconds, **claims},
+        separators=(',', ':'),
+    ).encode())
+
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+
+    # MeshCore 64-byte expanded key: bytes 0-31 = scalar, bytes 32-63 = nonce prefix
+    expanded_key = bytes.fromhex(private_key_hex)
+    public_key = bytes.fromhex(public_key_hex)
+    signature = _ed25519_sign_expanded(expanded_key, public_key, signing_input)
+
+    # meshcore-decoder encodes the signature as uppercase hex, not base64url
+    return f"{header_b64}.{payload_b64}.{signature.hex().upper()}"
+
+
+def _verify_auth_token_python(token: str, expected_public_key_hex: str | None = None) -> dict[str, Any]:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    from cryptography.exceptions import InvalidSignature
+
+    parts = token.split('.')
+    if len(parts) != 3:
+        raise Exception(f"Invalid token format: expected 3 parts, got {len(parts)}")
+
+    header_b64, payload_b64, signature_b64 = parts
+
+    payload = json.loads(base64url_decode(payload_b64))
+
+    if payload.get('exp', 0) < int(time.time()):
+        raise Exception("Token has expired")
+
+    pub_key_hex = expected_public_key_hex or payload.get('publicKey', '')
+    if not pub_key_hex:
+        raise Exception("No public key available for verification")
+
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    # Signature may be hex-encoded (meshcore-decoder format) or base64url (standard JWT)
     try:
-        cmd = ['meshcore-decoder', 'auth-token', public_key_hex, private_key_hex, '-e', str(expiry_seconds)]
-        
-        if claims:
-            claims_json = json.dumps(claims)
-            cmd.extend(['-c', claims_json])
-        
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=10
+        if all(c in '0123456789ABCDEFabcdef' for c in signature_b64) and len(signature_b64) == 128:
+            sig_bytes = bytes.fromhex(signature_b64)
+        else:
+            sig_bytes = base64url_decode(signature_b64)
+        Ed25519PublicKey.from_public_bytes(bytes.fromhex(pub_key_hex[:64])).verify(
+            sig_bytes, signing_input
         )
-        
-        if result.returncode != 0:
-            raise Exception(f"meshcore-decoder error: {result.stderr}")
-        
-        token = result.stdout.strip()
-        if not token or token.count('.') != 2:
-            raise Exception(f"Invalid token format: {token}")
-        
-        return token
-        
+    except InvalidSignature:
+        raise Exception("Token verification failed: invalid signature")
+
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# meshcore-decoder CLI fallback
+# ---------------------------------------------------------------------------
+
+def _create_auth_token_cli(public_key_hex: str, private_key_hex: str,
+                            expiry_seconds: int = 3600, **claims: Any) -> str:
+    cmd = ['meshcore-decoder', 'auth-token', public_key_hex, private_key_hex, '-e', str(expiry_seconds)]
+    if claims:
+        cmd.extend(['-c', json.dumps(claims)])
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
     except subprocess.TimeoutExpired:
         raise Exception("Token generation timed out")
     except FileNotFoundError:
-        raise Exception("meshcore-decoder CLI not found. Install it with: npm install -g @michaelhart/meshcore-decoder")
-    except Exception as e:
-        raise Exception(f"Failed to generate auth token: {str(e)}")
+        raise Exception("meshcore-decoder CLI not found. Install with: npm install -g @michaelhart/meshcore-decoder")
+    if result.returncode != 0:
+        raise Exception(f"meshcore-decoder error: {result.stderr}")
+    token = result.stdout.strip()
+    if not token or token.count('.') != 2:
+        raise Exception(f"Invalid token format from CLI: {token}")
+    return token
 
-def verify_auth_token(token: str, expected_public_key_hex: str | None = None) -> dict[str, Any]:
-    """
-    Verify a JWT-style auth token and return the payload if valid.
-    
-    Uses the meshcore-decoder CLI tool for signature verification.
-    
-    Args:
-        token: JWT-style token string (header.payload.signature)
-        expected_public_key_hex: Optional - verify the token was signed by this public key
-    
-    Returns:
-        Decoded payload dict if valid
-        
-    Raises:
-        Exception if token is invalid, expired, or signature verification fails
-    """
+
+def _verify_auth_token_cli(token: str, expected_public_key_hex: str | None = None) -> dict[str, Any]:
+    cmd = ['meshcore-decoder', 'verify-token', token, '--json']
+    if expected_public_key_hex:
+        cmd.extend(['-p', expected_public_key_hex])
     try:
-        cmd = ['meshcore-decoder', 'verify-token', token, '--json']
-        
-        if expected_public_key_hex:
-            cmd.extend(['-p', expected_public_key_hex])
-        
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=10
-        )
-        
-        if result.returncode != 0:
-            error_msg = result.stderr.strip() if result.stderr else "Verification failed"
-            raise Exception(f"Token verification failed: {error_msg}")
-        
-        # The CLI outputs JSON with {valid: true/false, payload: {...}, ...} when --json is used
-        output_json = result.stdout.strip()
-        if not output_json:
-            raise Exception("Empty output from verification")
-        
-        output = json.loads(output_json)
-        
-        if not output.get('valid', False):
-            error = output.get('error', 'Unknown verification error')
-            raise Exception(f"Token verification failed: {error}")
-        
-        # Check if token is expired (CLI includes this info)
-        if output.get('expired', False):
-            raise Exception("Token has expired")
-        
-        return output.get('payload', {})
-        
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
     except subprocess.TimeoutExpired:
         raise Exception("Token verification timed out")
     except FileNotFoundError:
-        raise Exception("meshcore-decoder CLI not found. Install it with: npm install -g @michaelhart/meshcore-decoder")
-    except json.JSONDecodeError as e:
-        raise Exception(f"Failed to parse verification output: {e}")
-    except Exception as e:
-        if "Token verification failed" in str(e) or "meshcore-decoder" in str(e) or "expired" in str(e).lower():
-            raise
-        raise Exception(f"Token verification error: {str(e)}")
+        raise Exception("meshcore-decoder CLI not found. Install with: npm install -g @michaelhart/meshcore-decoder")
+    if result.returncode != 0:
+        raise Exception(f"Token verification failed: {result.stderr.strip() or 'verification failed'}")
+    output = json.loads(result.stdout.strip())
+    if not output.get('valid', False):
+        raise Exception(f"Token verification failed: {output.get('error', 'unknown error')}")
+    if output.get('expired', False):
+        raise Exception("Token has expired")
+    return output.get('payload', {})
+
+
+# ---------------------------------------------------------------------------
+# Public API — tries Python, falls back to CLI
+# ---------------------------------------------------------------------------
+
+def create_auth_token(public_key_hex: str, private_key_hex: str,
+                      expiry_seconds: int = 3600, **claims: Any) -> str:
+    """
+    Create a JWT-style auth token signed with the device's Ed25519 private key.
+
+    Uses a pure-Python Ed25519 implementation (no external dependencies).
+    Falls back to the meshcore-decoder CLI on unexpected errors.
+    """
+    try:
+        return _create_auth_token_python(public_key_hex, private_key_hex, expiry_seconds, **claims)
+    except Exception:
+        return _create_auth_token_cli(public_key_hex, private_key_hex, expiry_seconds, **claims)
+
+
+def verify_auth_token(token: str, expected_public_key_hex: str | None = None) -> dict[str, Any]:
+    """
+    Verify a JWT auth token and return the payload if valid.
+
+    Uses the `cryptography` package when available; falls back to the
+    meshcore-decoder CLI otherwise.
+    """
+    try:
+        return _verify_auth_token_python(token, expected_public_key_hex)
+    except ImportError:
+        return _verify_auth_token_cli(token, expected_public_key_hex)
 
 
 def decode_token_payload(token: str) -> dict[str, Any]:
-    """
-    Decode a JWT payload without verifying the signature.
-    Useful for extracting claims before full verification.
-    
-    Args:
-        token: JWT-style token string (header.payload.signature)
-    
-    Returns:
-        Decoded payload dict
-        
-    Raises:
-        Exception if token format is invalid
-    """
-    try:
-        parts = token.split('.')
-        if len(parts) != 3:
-            raise Exception(f"Invalid token format: expected 3 parts, got {len(parts)}")
-        
-        # Decode the payload (second part)
-        payload_b64 = parts[1]
-        # Add padding if needed
-        padding = 4 - len(payload_b64) % 4
-        if padding != 4:
-            payload_b64 += '=' * padding
-        
-        payload_bytes = base64.urlsafe_b64decode(payload_b64)
-        return json.loads(payload_bytes.decode('utf-8'))
-        
-    except json.JSONDecodeError as e:
-        raise Exception(f"Failed to decode token payload: {e}")
-    except Exception as e:
-        if "Invalid token format" in str(e):
-            raise
-        raise Exception(f"Token decode error: {str(e)}")
+    """Decode JWT payload without verifying the signature."""
+    parts = token.split('.')
+    if len(parts) != 3:
+        raise Exception(f"Invalid token format: expected 3 parts, got {len(parts)}")
+    return json.loads(base64url_decode(parts[1]))
 
 
 def read_private_key_file(filepath: str) -> str:
-    """Read private key from file (64-byte hex format)"""
+    """Read private key from file (64-byte hex format)."""
     try:
         with open(filepath, 'r') as f:
-            key = f.read().strip()
-            key = ''.join(key.split())
-            if len(key) != 128:  # 64 bytes = 128 hex chars
+            key = ''.join(f.read().split())
+            if len(key) != 128:
                 raise ValueError(f"Invalid private key length: {len(key)} (expected 128)")
             int(key, 16)
             return key
@@ -176,28 +279,37 @@ def read_private_key_file(filepath: str) -> str:
     except ValueError as e:
         raise Exception(f"Invalid private key format: {str(e)}")
 
+
 if __name__ == "__main__":
-    # Test/CLI usage
-    if len(sys.argv) < 3:
-        print("Usage: python auth_token.py <public_key_hex> <private_key_hex_or_file>")
-        sys.exit(1)
-    
-    public_key = sys.argv[1]
-    private_key_input = sys.argv[2]
-    
-    if len(private_key_input) < 128:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a MeshCore Ed25519 JWT auth token")
+    parser.add_argument("public_key", help="Public key (hex)")
+    parser.add_argument("private_key", help="Private key (hex) or path to key file")
+    parser.add_argument("-e", "--expiry", type=int, default=3600, help="Expiry in seconds (default: 3600)")
+    parser.add_argument("-c", "--claims", default=None, help="Extra claims as JSON object")
+    args = parser.parse_args()
+
+    if len(args.private_key) < 128:
         try:
-            private_key = read_private_key_file(private_key_input)
-            print(f"Loaded private key from: {private_key_input}")
+            private_key = read_private_key_file(args.private_key)
         except Exception as e:
             print(f"Error: {e}")
             sys.exit(1)
     else:
-        private_key = private_key_input
-    
+        private_key = args.private_key
+
+    extra_claims: dict[str, Any] = {}
+    if args.claims:
+        try:
+            extra_claims = json.loads(args.claims)
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid JSON for --claims: {e}")
+            sys.exit(1)
+
     try:
-        token = create_auth_token(public_key, private_key)
-        print(f"Generated token: {token}")
+        token = create_auth_token(args.public_key, private_key, expiry_seconds=args.expiry, **extra_claims)
+        print(token)
     except Exception as e:
         print(f"Error: {e}")
         sys.exit(1)

--- a/bridge/ble_connection.py
+++ b/bridge/ble_connection.py
@@ -47,7 +47,11 @@ class BLESerialConnection(SerialConnection):
 
     def _run_ble_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
-        self._loop.run_until_complete(self._ble_loop())
+        self._ble_task = self._loop.create_task(self._ble_loop())
+        try:
+            self._loop.run_until_complete(self._ble_task)
+        except asyncio.CancelledError:
+            pass
 
     async def _scan_for_device(self) -> str | None:
         from bleak import BleakScanner  # type: ignore[import]
@@ -125,8 +129,8 @@ class BLESerialConnection(SerialConnection):
     def close(self) -> None:
         self._should_stop = True
         self._ble_connected = False
-        if not self._loop.is_closed():
-            self._loop.call_soon_threadsafe(self._loop.stop)
+        if not self._loop.is_closed() and hasattr(self, '_ble_task'):
+            self._loop.call_soon_threadsafe(self._ble_task.cancel)
         self._thread.join(timeout=5)
 
     @property

--- a/bridge/ble_connection.py
+++ b/bridge/ble_connection.py
@@ -152,7 +152,8 @@ class BLESerialConnection(SerialConnection):
         return key.upper() if key else None
 
     def get_privkey(self) -> str | None:
-        return None  # Not available over BLE
+        key: str = self._config.get('ble', {}).get('private_key', '')
+        return key.upper() if key else None
 
     def get_radio_info(self) -> str | None:
         return self._config.get('ble', {}).get('radio_info') or None

--- a/bridge/ble_connection.py
+++ b/bridge/ble_connection.py
@@ -1,0 +1,167 @@
+"""BLE serial connection for receiving MeshCore packet logs via Nordic UART Service."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import threading
+import time
+from typing import Any
+
+from .serial_connection import SerialConnection
+
+logger = logging.getLogger(__name__)
+
+NUS_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+NUS_TX_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+
+
+class BLESerialConnection(SerialConnection):
+    """Receive MeshCore packet-log lines via BLE Nordic UART Service (NUS).
+
+    The BLE log stream is one-way (device → client): the device sends log lines
+    as NUS TX notifications.  Bidirectional commands (get name, set time, etc.)
+    are not supported; device identity values must be provided in config.
+
+    The async BLE loop runs in a background thread so callers stay synchronous.
+    The connection auto-reconnects on drop; the main-loop watchdog handles the
+    case where the device disappears entirely.
+    """
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        self._config = config
+        self._lines: queue.Queue[str] = queue.Queue()
+        self._partial = ""
+        self._last_activity = time.time()
+        self._should_stop = False
+        self._ble_connected = False
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._run_ble_loop, daemon=True, name="BLE-Loop"
+        )
+        self._thread.start()
+
+    # ------------------------------------------------------------------
+    # Background BLE loop
+    # ------------------------------------------------------------------
+
+    def _run_ble_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._ble_loop())
+
+    async def _scan_for_device(self) -> str | None:
+        from bleak import BleakScanner  # type: ignore[import]
+
+        ble_cfg = self._config.get('ble', {})
+        scan_name: str | None = ble_cfg.get('scan_name')
+        timeout = float(ble_cfg.get('scan_timeout', 10))
+
+        logger.info("BLE: scanning for NUS device (name=%r, timeout=%.0fs)...", scan_name, timeout)
+
+        def match(device: Any, adv: Any) -> bool:
+            if scan_name and device.name != scan_name:
+                return False
+            return NUS_SERVICE_UUID in [str(s).lower() for s in adv.service_uuids]
+
+        device = await BleakScanner.find_device_by_filter(match, timeout=timeout)
+        if device:
+            logger.info("BLE: found %r at %s", device.name, device.address)
+            return device.address
+        return None
+
+    async def _ble_loop(self) -> None:
+        from bleak import BleakClient  # type: ignore[import]
+
+        ble_cfg = self._config.get('ble', {})
+        address: str = ble_cfg.get('address', 'scan')
+
+        if address == 'scan':
+            address = await self._scan_for_device() or ''
+            if not address:
+                logger.error("BLE: no device found during scan — giving up")
+                return
+
+        while not self._should_stop:
+            try:
+                async with BleakClient(address, timeout=10.0) as client:
+                    self._ble_connected = True
+                    logger.info("BLE: connected to %s", address)
+                    await client.start_notify(NUS_TX_UUID, self._on_notification)
+                    while client.is_connected and not self._should_stop:
+                        await asyncio.sleep(0.1)
+                    self._ble_connected = False
+                    if not self._should_stop:
+                        logger.info("BLE: disconnected, reconnecting in 5s...")
+                        await asyncio.sleep(5)
+            except Exception as exc:
+                self._ble_connected = False
+                if not self._should_stop:
+                    logger.warning("BLE: connection error (%s), retrying in 5s", exc)
+                    await asyncio.sleep(5)
+
+    def _on_notification(self, handle: Any, data: bytearray) -> None:
+        """Called from the BLE asyncio thread for each incoming NUS notification."""
+        self._partial += data.decode('utf-8', errors='replace')
+        while '\n' in self._partial:
+            line, self._partial = self._partial.split('\n', 1)
+            line = line.rstrip('\r')
+            if line:
+                self._lines.put(line)
+                self._last_activity = time.time()
+
+    # ------------------------------------------------------------------
+    # SerialConnection interface — read side
+    # ------------------------------------------------------------------
+
+    def read_line(self) -> str | None:
+        try:
+            return self._lines.get_nowait()
+        except queue.Empty:
+            return None
+
+    def seconds_since_activity(self) -> float:
+        return time.time() - self._last_activity
+
+    def close(self) -> None:
+        self._should_stop = True
+        self._ble_connected = False
+        if not self._loop.is_closed():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5)
+
+    @property
+    def is_open(self) -> bool:
+        return self._thread.is_alive() and not self._should_stop
+
+    # ------------------------------------------------------------------
+    # SerialConnection interface — device info from config
+    # ------------------------------------------------------------------
+
+    def set_time(self) -> None:
+        pass  # Cannot send commands over one-way BLE log stream
+
+    def get_name(self) -> str | None:
+        return self._config.get('ble', {}).get('device_name') or None
+
+    def get_pubkey(self) -> str | None:
+        key: str = self._config.get('ble', {}).get('public_key', '')
+        return key.upper() if key else None
+
+    def get_privkey(self) -> str | None:
+        return None  # Not available over BLE
+
+    def get_radio_info(self) -> str | None:
+        return self._config.get('ble', {}).get('radio_info') or None
+
+    def get_firmware_version(self) -> str | None:
+        return None
+
+    def get_board_type(self) -> str | None:
+        return None
+
+    def get_device_stats(self) -> dict[str, Any]:
+        return {}
+
+    def execute_command(self, command: str, timeout: float = 10.0) -> tuple[bool, str]:
+        logger.warning("BLE: execute_command not supported over one-way log stream (%r)", command)
+        return False, "Not supported over BLE log stream"

--- a/bridge/broker_client.py
+++ b/bridge/broker_client.py
@@ -80,12 +80,20 @@ class PahoBrokerClient(BrokerClient):
         if on_message:
             self._client.on_message = on_message
 
+        def _on_log(client, userdata, level, buf):
+            logger.debug(f"[paho] {buf}")
+        self._client.on_log = _on_log
+
         if tls_enabled:
-            if tls_verify:
-                self._client.tls_set(cert_reqs=ssl.CERT_REQUIRED)
-                self._client.tls_insecure_set(False)
-            else:
-                self._client.tls_set(cert_reqs=ssl.CERT_NONE)
+            ctx = ssl.create_default_context()
+            if not tls_verify:
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+            if transport == "websockets":
+                # WebSocket upgrade requires HTTP/1.1; prevent TLS from negotiating HTTP/2
+                ctx.set_alpn_protocols(["http/1.1"])
+            self._client.tls_set_context(ctx)
+            if not tls_verify:
                 self._client.tls_insecure_set(True)
 
         if transport == "websockets":

--- a/bridge/serial_connection.py
+++ b/bridge/serial_connection.py
@@ -337,8 +337,26 @@ class RealSerialConnection(SerialConnection):
         return getattr(self._port, 'is_open', False)
 
 
-def connect(config: dict[str, Any]) -> RealSerialConnection | None:
-    """Try configured serial ports and return the first successful connection."""
+def connect(config: dict[str, Any]) -> SerialConnection | None:
+    """Return a connection to the MeshCore device.
+
+    If ``[ble]`` is enabled in config, returns a ``BLESerialConnection``
+    (requires the ``bleak`` package).  Otherwise tries each configured serial
+    port in order and returns the first that opens successfully.
+    """
+    ble_cfg = config.get('ble', {})
+    if ble_cfg.get('enabled', False):
+        try:
+            from .ble_connection import BLESerialConnection
+        except ImportError:
+            logger.error(
+                "BLE mode is enabled but 'bleak' is not installed. "
+                "Run: pip install bleak"
+            )
+            return None
+        logger.info("BLE mode: connecting via Nordic UART Service")
+        return BLESerialConnection(config)
+
     serial_cfg = config.get('serial', {})
     ports = serial_cfg.get('ports', ['/dev/ttyACM0'])
     baud_rate = serial_cfg.get('baud_rate', 115200)

--- a/config.toml.example
+++ b/config.toml.example
@@ -36,6 +36,40 @@ timeout = 2
 # Watchdog: seconds with no data before forcing serial reconnect (0 to disable)
 watchdog_timeout = 900
 
+[ble]
+# Receive MeshCore packet logs wirelessly via Bluetooth Low Energy (Nordic UART Service).
+# Requires the 'bleak' Python package: pip install bleak
+#
+# When enabled, BLE replaces the serial connection as the log source.
+# Because the BLE log stream is one-way (device → host), bidirectional serial
+# commands (get name, set time, etc.) are not available — provide device_name,
+# public_key, and radio_info here instead.
+#
+# The MeshCore firmware must be built with MESH_PACKET_LOGGING=1 and
+# BLE_PACKET_LOGGING=1 (ESP32 or nRF52 only).
+enabled = false
+
+# BLE device address to connect to.
+# Use "scan" to auto-discover by scanning for the Nordic UART Service UUID.
+# On Linux/Windows this is a MAC address (e.g. "AA:BB:CC:DD:EE:FF").
+# On macOS this is a CoreBluetooth UUID (e.g. "12345678-ABCD-...").
+address = "scan"
+
+# When address = "scan": filter by advertised device name (recommended).
+# Leave empty to connect to the first NUS device found.
+scan_name = ""
+
+# Seconds to spend scanning before giving up.
+scan_timeout = 10
+
+# Device identity — required when BLE is enabled (cannot be queried over BLE).
+# device_name: shown as the repeater name in MQTT and logs.
+device_name = ""
+# public_key: 64 hex chars, used for MQTT topic routing.
+public_key = ""
+# radio_info: free-form string describing the radio config (e.g. "SF9 BW125").
+radio_info = ""
+
 [topics]
 # Topic templates - supported variables: {IATA}, {PUBLIC_KEY}
 status = "meshcore/{IATA}/{PUBLIC_KEY}/status"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [project]
+version = "0.0.1"
 name = "meshcoretomqtt"
 requires-python = ">=3.11"
+dependencies = [
+    "paho-mqtt>=2.1.0",
+    "pyserial>=3.5",
+]
 
 [project.optional-dependencies]
 test = ["pytest>=7.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires-python = ">=3.11"
 
 [project.optional-dependencies]
 test = ["pytest>=7.0"]
+ble = ["bleak>=0.20"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_auth_token.py
+++ b/tests/test_auth_token.py
@@ -1,0 +1,116 @@
+"""Tests for native Python Ed25519 JWT implementation in auth_token.py."""
+from __future__ import annotations
+
+import time
+import pytest
+
+cryptography = pytest.importorskip("cryptography", reason="cryptography package not installed")
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat, PrivateFormat, NoEncryption
+
+from auth_token import (
+    _create_auth_token_python,
+    _verify_auth_token_python,
+    decode_token_payload,
+)
+
+
+def make_keypair() -> tuple[str, str]:
+    """Generate a random Ed25519 keypair in MeshCore expanded-key hex format.
+
+    MeshCore stores private keys as the expanded Ed25519 key (SHA-512 of seed,
+    clamped) — NOT as seed || public_key.  bytes 0-31 are the clamped scalar,
+    bytes 32-63 are the nonce prefix.
+    """
+    import hashlib
+    priv = Ed25519PrivateKey.generate()
+    seed = priv.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+    pub = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    expanded = bytearray(hashlib.sha512(seed).digest())
+    expanded[0] &= 248
+    expanded[31] &= 63
+    expanded[31] |= 64
+    return pub.hex().upper(), bytes(expanded).hex().upper()
+
+
+class TestCreateToken:
+    def test_returns_three_part_jwt(self):
+        pub, priv = make_keypair()
+        token = _create_auth_token_python(pub, priv)
+        assert token.count('.') == 2
+
+    def test_payload_contains_public_key(self):
+        pub, priv = make_keypair()
+        token = _create_auth_token_python(pub, priv)
+        payload = decode_token_payload(token)
+        assert payload['publicKey'] == pub.upper()
+
+    def test_payload_contains_expiry(self):
+        pub, priv = make_keypair()
+        before = int(time.time())
+        token = _create_auth_token_python(pub, priv, expiry_seconds=3600)
+        payload = decode_token_payload(token)
+        assert payload['exp'] >= before + 3600
+
+    def test_payload_contains_iat(self):
+        pub, priv = make_keypair()
+        before = int(time.time())
+        token = _create_auth_token_python(pub, priv)
+        payload = decode_token_payload(token)
+        assert payload['iat'] >= before
+
+    def test_extra_claims_included(self):
+        pub, priv = make_keypair()
+        token = _create_auth_token_python(pub, priv, aud="test.broker", owner="AABB")
+        payload = decode_token_payload(token)
+        assert payload['aud'] == "test.broker"
+        assert payload['owner'] == "AABB"
+
+    def test_header_alg(self):
+        import base64, json
+        pub, priv = make_keypair()
+        token = _create_auth_token_python(pub, priv)
+        header_b64 = token.split('.')[0]
+        padding = 4 - len(header_b64) % 4
+        if padding != 4:
+            header_b64 += '=' * padding
+        header = json.loads(base64.urlsafe_b64decode(header_b64))
+        assert header['alg'] == 'Ed25519'
+
+
+class TestVerifyToken:
+    def test_valid_token_roundtrip(self):
+        pub, priv = make_keypair()
+        token = _create_auth_token_python(pub, priv, command="get name")
+        payload = _verify_auth_token_python(token, pub)
+        assert payload['publicKey'] == pub.upper()
+        assert payload['command'] == "get name"
+
+    def test_verify_uses_payload_public_key_when_not_specified(self):
+        pub, priv = make_keypair()
+        token = _create_auth_token_python(pub, priv)
+        payload = _verify_auth_token_python(token)
+        assert payload['publicKey'] == pub.upper()
+
+    def test_rejects_tampered_payload(self):
+        pub, priv = make_keypair()
+        token = _create_auth_token_python(pub, priv)
+        header, payload_b64, sig = token.split('.')
+        # Flip one char in the payload
+        tampered = payload_b64[:-1] + ('A' if payload_b64[-1] != 'A' else 'B')
+        with pytest.raises(Exception):
+            _verify_auth_token_python(f"{header}.{tampered}.{sig}", pub)
+
+    def test_rejects_wrong_public_key(self):
+        pub, priv = make_keypair()
+        other_pub, _ = make_keypair()
+        token = _create_auth_token_python(pub, priv)
+        with pytest.raises(Exception):
+            _verify_auth_token_python(token, other_pub)
+
+    def test_rejects_expired_token(self):
+        pub, priv = make_keypair()
+        token = _create_auth_token_python(pub, priv, expiry_seconds=-1)
+        with pytest.raises(Exception, match="expired"):
+            _verify_auth_token_python(token, pub)

--- a/tests/test_ble_connection.py
+++ b/tests/test_ble_connection.py
@@ -121,8 +121,16 @@ class TestDeviceInfo:
         conn = _make_conn()
         assert conn.get_radio_info() is None
 
-    def test_get_privkey_always_none(self):
-        conn = _make_conn({'private_key': 'should_be_ignored'})
+    def test_get_privkey_returns_config_value(self):
+        conn = _make_conn({'private_key': 'aabbcc'})
+        assert conn.get_privkey() == 'AABBCC'
+
+    def test_get_privkey_empty_returns_none(self):
+        conn = _make_conn({'private_key': ''})
+        assert conn.get_privkey() is None
+
+    def test_get_privkey_missing_returns_none(self):
+        conn = _make_conn()
         assert conn.get_privkey() is None
 
     def test_get_firmware_version_always_none(self):

--- a/tests/test_ble_connection.py
+++ b/tests/test_ble_connection.py
@@ -1,0 +1,144 @@
+"""Tests for BLESerialConnection — pure logic, no BLE hardware required."""
+from __future__ import annotations
+
+import queue
+import time
+
+from bridge.ble_connection import BLESerialConnection
+
+
+def _make_conn(ble_cfg: dict | None = None) -> BLESerialConnection:
+    """Create a BLESerialConnection without starting the BLE background thread."""
+    config = {'ble': ble_cfg or {}}
+    conn = BLESerialConnection.__new__(BLESerialConnection)
+    conn._config = config
+    conn._lines = queue.Queue()
+    conn._partial = ""
+    conn._last_activity = time.time()
+    conn._should_stop = False
+    conn._ble_connected = False
+    return conn
+
+
+# ------------------------------------------------------------------
+# _on_notification line-buffering
+# ------------------------------------------------------------------
+
+class TestOnNotification:
+    def test_single_complete_line(self):
+        conn = _make_conn()
+        conn._on_notification(None, bytearray(b"hello\n"))
+        assert conn.read_line() == "hello"
+
+    def test_strips_carriage_return(self):
+        conn = _make_conn()
+        conn._on_notification(None, bytearray(b"hello\r\n"))
+        assert conn.read_line() == "hello"
+
+    def test_partial_then_complete(self):
+        conn = _make_conn()
+        conn._on_notification(None, bytearray(b"hel"))
+        assert conn.read_line() is None
+        conn._on_notification(None, bytearray(b"lo\n"))
+        assert conn.read_line() == "hello"
+
+    def test_multiple_lines_in_one_notification(self):
+        conn = _make_conn()
+        conn._on_notification(None, bytearray(b"line1\nline2\n"))
+        assert conn.read_line() == "line1"
+        assert conn.read_line() == "line2"
+        assert conn.read_line() is None
+
+    def test_chunked_across_three_notifications(self):
+        conn = _make_conn()
+        conn._on_notification(None, bytearray(b"abc"))
+        conn._on_notification(None, bytearray(b"def"))
+        conn._on_notification(None, bytearray(b"ghi\n"))
+        assert conn.read_line() == "abcdefghi"
+
+    def test_empty_line_not_queued(self):
+        conn = _make_conn()
+        conn._on_notification(None, bytearray(b"\n"))
+        assert conn.read_line() is None
+
+    def test_updates_last_activity(self):
+        conn = _make_conn()
+        conn._last_activity = time.time() - 100
+        conn._on_notification(None, bytearray(b"data\n"))
+        assert conn.seconds_since_activity() < 1
+
+    def test_does_not_update_activity_on_empty_line(self):
+        conn = _make_conn()
+        conn._last_activity = time.time() - 100
+        conn._on_notification(None, bytearray(b"\n"))
+        assert conn.seconds_since_activity() >= 99
+
+    def test_invalid_utf8_replaced(self):
+        conn = _make_conn()
+        conn._on_notification(None, bytearray(b"\xff\xfe\n"))
+        line = conn.read_line()
+        assert line is not None
+        assert '\n' not in line
+
+    def test_trailing_partial_held(self):
+        conn = _make_conn()
+        conn._on_notification(None, bytearray(b"complete\npartial"))
+        assert conn.read_line() == "complete"
+        assert conn.read_line() is None
+        assert conn._partial == "partial"
+
+
+# ------------------------------------------------------------------
+# Device info from config
+# ------------------------------------------------------------------
+
+class TestDeviceInfo:
+    def test_get_name(self):
+        conn = _make_conn({'device_name': 'MyRepeater'})
+        assert conn.get_name() == 'MyRepeater'
+
+    def test_get_name_empty_returns_none(self):
+        conn = _make_conn({'device_name': ''})
+        assert conn.get_name() is None
+
+    def test_get_name_missing_returns_none(self):
+        conn = _make_conn()
+        assert conn.get_name() is None
+
+    def test_get_pubkey_uppercases(self):
+        conn = _make_conn({'public_key': 'ab' * 32})
+        assert conn.get_pubkey() == 'AB' * 32
+
+    def test_get_pubkey_empty_returns_none(self):
+        conn = _make_conn({'public_key': ''})
+        assert conn.get_pubkey() is None
+
+    def test_get_radio_info(self):
+        conn = _make_conn({'radio_info': 'SF9 BW125'})
+        assert conn.get_radio_info() == 'SF9 BW125'
+
+    def test_get_radio_info_missing_returns_none(self):
+        conn = _make_conn()
+        assert conn.get_radio_info() is None
+
+    def test_get_privkey_always_none(self):
+        conn = _make_conn({'private_key': 'should_be_ignored'})
+        assert conn.get_privkey() is None
+
+    def test_get_firmware_version_always_none(self):
+        assert _make_conn().get_firmware_version() is None
+
+    def test_get_board_type_always_none(self):
+        assert _make_conn().get_board_type() is None
+
+    def test_get_device_stats_always_empty(self):
+        assert _make_conn().get_device_stats() == {}
+
+    def test_set_time_is_noop(self):
+        _make_conn().set_time()  # must not raise
+
+    def test_execute_command_returns_false(self):
+        conn = _make_conn()
+        success, msg = conn.execute_command("get name")
+        assert success is False
+        assert "BLE" in msg


### PR DESCRIPTION
This PR adds support for connecting to BLE devices for mesh packet logging.

Corresponding MeshCore PR: https://github.com/meshcore-dev/MeshCore/pull/2039, which adds BLE mesh packet logging support to MeshCore.

This approach has a few notable aspects:

- The config TOML will need to contain the MeshCore device's public and potentially also the private key. This is necessary because there is no serial connection, and thus meshcoretomqtt cannot retrieve those keys by itself. I also thought it would be a bad idea to extend the BLE protocol to allow fetching those, as then anyone with a Bluetooth scanner would be able to do this.
- Because I found it annoying that I'd have to install NodeJS just for the token auth, this PR also includes a pure-Python implementation for the auth token generation. Let me know if that's acceptable, or it should be pulled out into another PR.

I've tested this with [my branch of MeshCore](https://github.com/meshcore-dev/MeshCore/pull/2039) on a Heltec Wireless Tracker, and this PR on a macbook.

Limitation: this PR doesn't deal with statistics, as those are requested by meshcoretomqtt via the serial connection. In order to implement that over BLE, that needs to be designed first. For one, that would need some reconsideration whether it's desirable to expose via unauthenticated BLE calls.

Disclaimer: this PR was made with the help of Claude AI. I'm a human, though, and happy to personally work on any feedback.