### PR TITLE
Support current MeshCore packet log formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ you can easily troubleshoot packets through the mesh. You will need to build a
 custom image with packet logging and/or debug for your repeater to view the
 data.
 
+The parser supports the current MeshCore packet log variants from `main`,
+including repeater packet logs without `hash=` and dispatcher/serial logs that
+include `time=` and `hash=`.
+
 One way of tracking a message through the mesh is filtering the MQTT data on the
-hash field as each message has a unique hash. You can see which repeaters the
-message hits!
+`hash` field when the source log format includes it. Dispatcher/serial packet
+logs include `hash=...`, while current repeater packet logs may not.
 
 ## Quick Install
 
@@ -516,4 +520,3 @@ Direct packet...
 Topic: meshcore/SEA/A1B2.../packets QoS: 0
 {"origin": "ag loft rpt", "origin_id": "A1B2...", "timestamp": "2025-03-15T23:09:00.710459", "type": "PACKET", "direction": "rx", "time": "23:08:59", "date": "15/3/2025", "len": "22", "packet_type": "2", "route": "D", "payload_len": "20", "raw": "0A1B2C...", "SNR": "5", "RSSI": "-93", "score": "1000", "hash": "890BFA3069FD1250", "path": "C2 -> E2"}
 ```
-

--- a/bridge/message_parser.py
+++ b/bridge/message_parser.py
@@ -18,7 +18,9 @@ logger = logging.getLogger(__name__)
 RAW_PATTERN = re.compile(r"(\d{2}:\d{2}:\d{2}) - (\d{1,2}/\d{1,2}/\d{4}) U RAW: (.*)")
 PACKET_PATTERN = re.compile(
     r"(\d{2}:\d{2}:\d{2}) - (\d{1,2}/\d{1,2}/\d{4}) U: (RX|TX), len=(\d+) \(type=(\d+), route=([A-Z]), payload_len=(\d+)\)"
-    r"(?: SNR=(-?\d+) RSSI=(-?\d+) score=(\d+)( time=(\d+))? hash=([0-9A-F]+)(?: \[(.*)\])?)?"
+    r"(?: SNR=(-?\d+) RSSI=(-?\d+) score=(\d+)(?: time=(\d+))?)?"
+    r"(?: hash=([0-9A-F]+))?"
+    r"(?: \[(.*)\])?$"
 )
 
 
@@ -82,12 +84,12 @@ def parse_and_publish(state: BridgeState, line: str) -> None:
                 "SNR": packet_match.group(8),
                 "RSSI": packet_match.group(9),
                 "score": packet_match.group(10),
-                "duration": packet_match.group(12),
-                "hash": packet_match.group(13)
+                "duration": packet_match.group(11),
+                "hash": packet_match.group(12)
             })
 
-            if packet_match.group(6) == "D" and packet_match.group(14):
-                payload["path"] = packet_match.group(14)
+            if packet_match.group(6) == "D" and packet_match.group(13):
+                payload["path"] = packet_match.group(13)
 
         message.update(payload)
         packets_topic = topics.get_topic(state, "packets")

--- a/tests/test_message_parser.py
+++ b/tests/test_message_parser.py
@@ -31,6 +31,14 @@ class TestPacketPattern:
         assert match.group(9) == "-80"
         assert match.group(10) == "100"
 
+    def test_matches_current_repeater_rx_packet_without_hash(self):
+        line = "12:34:56 - 1/15/2025 U: RX, len=64 (type=1, route=D, payload_len=48) SNR=10 RSSI=-80 score=100 [BB -> AA]"
+        match = PACKET_PATTERN.match(line)
+        assert match is not None
+        assert match.group(3) == "RX"
+        assert match.group(12) is None
+        assert match.group(13) == "BB -> AA"
+
     def test_matches_tx_packet(self):
         line = "12:34:56 - 1/15/2025 U: TX, len=32 (type=2, route=F, payload_len=16)"
         match = PACKET_PATTERN.match(line)
@@ -103,6 +111,19 @@ class TestParseAndPublish:
         assert msg['SNR'] == "-5"
         assert msg['RSSI'] == "-100"
         assert msg['score'] == "50"
+
+    def test_parses_current_repeater_rx_packet_without_hash(self):
+        state, broker = self._make_state()
+        line = "12:34:56 - 1/15/2025 U: RX, len=64 (type=1, route=D, payload_len=48) SNR=10 RSSI=-80 score=100 [BB -> AA]"
+        parse_and_publish(state, line)
+        assert len(broker.published) == 1
+        msg = json.loads(broker.published[0][1])
+        assert msg['direction'] == "rx"
+        assert msg['SNR'] == "10"
+        assert msg['RSSI'] == "-80"
+        assert msg['score'] == "100"
+        assert msg.get('hash') is None
+        assert msg['path'] == "BB -> AA"
 
 
 class TestIataInPublishedTopics:


### PR DESCRIPTION
## Summary
- accept current repeater packet logs that do not include `hash=`
- keep support for dispatcher/serial packet logs that include `time=` and `hash=`
- document the supported MeshCore log variants more precisely

## Validation
- python -m pytest tests/test_message_parser.py tests/test_topics.py tests/test_config_loader.py
