### PR TITLE
Fix WebSocket reconnect blocked indefinitely when proxy loses backend

### DIFF
--- a/bridge/mqtt_manager.py
+++ b/bridge/mqtt_manager.py
@@ -434,11 +434,12 @@ class MqttManager:
             return None
 
         try:
+            _prior_timeout = _socket.getdefaulttimeout()
             _socket.setdefaulttimeout(30)
             try:
                 broker_client.connect(server, port, keepalive=keepalive)
             finally:
-                _socket.setdefaulttimeout(None)
+                _socket.setdefaulttimeout(_prior_timeout)
 
             if transport == "websockets":
                 state.ws_ping_threads[broker_idx] = {'active': True}

--- a/bridge/mqtt_manager.py
+++ b/bridge/mqtt_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import random
+import socket as _socket
 import threading
 import time
 from typing import Any, TYPE_CHECKING
@@ -433,7 +434,11 @@ class MqttManager:
             return None
 
         try:
-            broker_client.connect(server, port, keepalive=keepalive)
+            _socket.setdefaulttimeout(30)
+            try:
+                broker_client.connect(server, port, keepalive=keepalive)
+            finally:
+                _socket.setdefaulttimeout(None)
 
             if transport == "websockets":
                 state.ws_ping_threads[broker_idx] = {'active': True}


### PR DESCRIPTION
## Problem

When using WebSocket transport behind a terminating reverse proxy (e.g. Cloudflare), the proxy keeps the client TCP connection alive after losing its backend but never forwards the WebSocket upgrade request. paho's `connect()` blocks `recv()` indefinitely waiting for the `101 Switching Protocols` response, freezing the main thread permanently.

The service logs a single reconnect attempt and then hangs forever — no further attempts, no exit, no recovery without a manual restart. Plain TCP (port 1883) connections are not affected because a dead backend causes an immediate `ECONNREFUSED`.

Closes #42

## Fix

Set a 30-second socket timeout around `connect()`. paho creates a new socket internally that inherits the default timeout, so a stalled WebSocket handshake raises `socket.timeout` after 30 seconds. The existing `except Exception` handler catches it, returns `None`, and the normal backoff / exit-after-N-failures path resumes.

The `finally` block restores the timeout to `None` immediately after `connect()` so that paho's background loop thread (started directly after by `loop_start()`) is not affected.

```python
_socket.setdefaulttimeout(30)
try:
    broker_client.connect(server, port, keepalive=keepalive)
finally:
    _socket.setdefaulttimeout(None)
```

## Verification

Reproduced and verified with a Docker-based test setup: a controllable TCP proxy simulating Cloudflare's behaviour (keeps client TCP alive, absorbs all data). Without the fix the service freezes on attempt #1 indefinitely. With the fix:

```
T+0 s    proxy loses backend (absorb mode)
T+120 s  Disconnected — Keep alive timeout
T+121 s  Reconnecting (attempt #1)
T+151 s  Failed to connect: timed out
T+152 s  Reconnecting (attempt #2)
...
T+~900s  CRITICAL: 12 consecutive failures — exiting for service restart
```