### PR TITLE
Fix reconnect backoff: use per-broker delay and fresh timestamp

### DIFF
--- a/bridge/mqtt_manager.py
+++ b/bridge/mqtt_manager.py
@@ -132,10 +132,13 @@ class MqttManager:
             else:
                 mqtt_info['failed_attempts'] = failed_attempts + 1
                 jitter = random.uniform(-0.5, 0.5)
-                delay = max(0, state.reconnect_delay + jitter)
-                mqtt_info['reconnect_at'] = current_time + delay
-                state.reconnect_delay = min(state.reconnect_delay * state.reconnect_backoff, state.max_reconnect_delay)
+                mqtt_info['reconnect_at'] = time.time() + max(0, mqtt_info['reconnect_delay'] + jitter)
                 logger.warning(f"[{broker_name}] Failed to recreate client (attempt #{failed_attempts + 1}/{state.max_reconnect_attempts})")
+
+            mqtt_info['reconnect_delay'] = min(
+                mqtt_info['reconnect_delay'] * state.reconnect_backoff,
+                state.max_reconnect_delay
+            )
 
     def stop_websocket_ping_thread(self, broker_idx: int) -> None:
         """Cleanly stop the WebSocket ping thread for a broker."""
@@ -157,8 +160,6 @@ class MqttManager:
         broker_idx = userdata.get('broker_idx', None) if userdata else None
 
         if rc == 0:
-            state.reconnect_delay = 1.0
-
             mqtt_info = None
             for info in state.mqtt_clients:
                 if info['broker_idx'] == broker_idx:
@@ -176,6 +177,7 @@ class MqttManager:
             mqtt_info['connected'] = True
             mqtt_info['connecting_since'] = 0
             mqtt_info['connect_time'] = current_time
+            mqtt_info['reconnect_delay'] = 1.0
 
             if was_connected and not is_first_connect:
                 logger.info(f"[{broker_name}] Reconnected to broker")
@@ -234,7 +236,7 @@ class MqttManager:
                 already_disconnected = not info.get('connected', False)
                 info['connected'] = False
                 info['connecting_since'] = 0
-                info['reconnect_at'] = time.time() + state.reconnect_delay
+                info['reconnect_at'] = time.time() + info.get('reconnect_delay', 1.0)
 
                 connect_time = info.get('connect_time', 0)
                 if connect_time > 0 and (time.time() - connect_time) < 120:
@@ -456,6 +458,7 @@ class MqttManager:
                 'connecting_since': time.time(),
                 'connect_time': 0,
                 'reconnect_at': 0,
+                'reconnect_delay': 1.0,
                 'failed_attempts': 0
             }
         except Exception as e:

--- a/bridge/state.py
+++ b/bridge/state.py
@@ -68,7 +68,6 @@ class BridgeState:
         self.sync_time_at_start: bool = config.get('general', {}).get('sync_time', True)
 
         # Reconnect params
-        self.reconnect_delay: float = 1.0
         self.max_reconnect_delay: float = 120.0
         self.reconnect_backoff: float = 1.5
         self.max_reconnect_attempts: int = 12

--- a/tests/test_mqtt_manager.py
+++ b/tests/test_mqtt_manager.py
@@ -1,6 +1,9 @@
 """Tests for MqttManager orchestration."""
 from __future__ import annotations
 
+import time
+from unittest.mock import patch
+
 import pytest
 
 from bridge.mqtt_manager import MqttManager
@@ -97,3 +100,66 @@ class TestReconnectBehavior:
         # there's no real MQTT server, but it should clear the token cache
         manager.reconnect_disconnected_brokers()
         assert 0 not in state.token_cache
+
+    def test_backoff_is_independent_per_broker(self):
+        """Two brokers maintain separate reconnect_delay counters.
+
+        Broker 0 fails repeatedly so its backoff grows.
+        Broker 1 stays connected throughout, then disconnects.
+        Broker 1's reconnect_delay must still be 1.0 — unaffected by broker 0.
+        When broker 1 subsequently fails its first reconnect attempt its own
+        backoff starts at 1.0 and grows independently from broker 0's.
+        """
+        config = make_config()
+        config['broker'] = [
+            {'name': 'b0', 'enabled': True, 'server': 'host0', 'port': 1883,
+             'transport': 'tcp', 'qos': 0, 'retain': False,
+             'auth': {'method': 'none'}, 'tls': {'enabled': False}},
+            {'name': 'b1', 'enabled': True, 'server': 'host1', 'port': 1883,
+             'transport': 'tcp', 'qos': 0, 'retain': False,
+             'auth': {'method': 'none'}, 'tls': {'enabled': False}},
+        ]
+        state = make_test_state(config=config, repeater_name="Node", repeater_pub_key="AA" * 32)
+        manager = MqttManager(state)
+        state.mqtt_manager = manager
+
+        def make_client_info(idx, connected):
+            return {
+                'client': FakeBrokerClient(),
+                'broker_idx': idx,
+                'connected': connected,
+                'connecting_since': 0,
+                'connect_time': time.time() - 300 if connected else 0,
+                'reconnect_at': 0,
+                'reconnect_delay': 1.0,
+                'failed_attempts': 0,
+            }
+
+        state.mqtt_clients = [make_client_info(0, False), make_client_info(1, True)]
+        state.mqtt_connected = True
+
+        # Fail broker 0 five times — its delay should grow: 1.0 → 1.5 → 2.25 → 3.375 → 5.06 → 7.59
+        with patch.object(manager, '_create_and_connect_broker', return_value=None):
+            for _ in range(5):
+                state.mqtt_clients[0]['reconnect_at'] = 0
+                manager.reconnect_disconnected_brokers()
+
+        assert state.mqtt_clients[0]['reconnect_delay'] == pytest.approx(1.0 * 1.5 ** 5, rel=1e-3)
+        assert state.mqtt_clients[1]['reconnect_delay'] == 1.0, \
+            "broker 1 delay must be unaffected by broker 0 failures"
+
+        # Broker 1 disconnects — reconnect_at should use its own delay (1.0)
+        t_before = time.time()
+        manager.on_mqtt_disconnect(None, {'name': 'b1', 'broker_idx': 1}, None, 0, None)
+        t_after = time.time()
+
+        assert state.mqtt_clients[1]['reconnect_delay'] == 1.0
+        assert t_before + 1.0 <= state.mqtt_clients[1]['reconnect_at'] <= t_after + 1.0
+
+        # Broker 1 fails its first reconnect — its own backoff starts from 1.0
+        with patch.object(manager, '_create_and_connect_broker', return_value=None):
+            state.mqtt_clients[1]['reconnect_at'] = 0
+            manager.reconnect_disconnected_brokers()
+
+        assert state.mqtt_clients[1]['reconnect_delay'] == pytest.approx(1.5, rel=1e-3), \
+            "broker 1 first failure must grow from 1.0, not from broker 0's grown value"


### PR DESCRIPTION
## Problem

The exponential backoff between reconnect attempts was completely ineffective due to two flaws.

**Stale timestamp:** `reconnect_at` was calculated using a `current_time` captured before `connect()` is called. On WebSocket transport `connect()` blocks for up to 30 seconds waiting for the handshake. By the time the attempt fails, `current_time + delay` is already in the past and the main loop retries immediately — the growing delay was silently discarded. In practice all 12 attempts fired without any pause between them.

**Shared global state:** `state.reconnect_delay` was a single value shared across all broker connections. One broker's failures inflated the initial wait for an unrelated broker on its first disconnect. Conversely, any successful reconnect reset `reconnect_delay` to `1.0` for every broker, discarding the accumulated backoff of brokers still struggling.

Closes #44

## Fix

Replace `current_time` with `time.time()` at the point `reconnect_at` is assigned, so the delay is measured from after the failed attempt rather than before it.

Move `reconnect_delay` out of `BridgeState` and into each broker's `mqtt_info` dict, initialised to `1.0` on creation and reset to `1.0` only when that specific broker successfully connects. `reconnect_backoff` and `max_reconnect_delay` remain on `BridgeState` as static configuration.

The backoff update is moved after the `if/else` block so it advances regardless of whether the attempt produced a new client dict or failed immediately.