### PR TITLE
Fixes the issue of Broker specific topics not being used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv/
 .DS_Store
 .claude/settings.local.json
 .pytest_cache/
+uv.lock

--- a/bridge/message_parser.py
+++ b/bridge/message_parser.py
@@ -50,9 +50,7 @@ def parse_and_publish(state: BridgeState, line: str) -> None:
                 "type": "DEBUG",
                 "message": line
             })
-            debug_topic = topics.get_topic(state, "debug")
-            if debug_topic:
-                safe_publish(state, debug_topic, json.dumps(message))
+            safe_publish(state, "debug", json.dumps(message))
             return
 
     # Handle Packet messages (RX and TX)
@@ -90,6 +88,4 @@ def parse_and_publish(state: BridgeState, line: str) -> None:
                 payload["path"] = packet_match.group(14)
 
         message.update(payload)
-        packets_topic = topics.get_topic(state, "packets")
-        if packets_topic:
-            safe_publish(state, packets_topic, json.dumps(message))
+        safe_publish(state, "packets", json.dumps(message))

--- a/bridge/mqtt_publish.py
+++ b/bridge/mqtt_publish.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def safe_publish(
     state: BridgeState,
-    topic: str,
+    topic_type: str,
     payload: str,
     retain: bool = False,
     client: BrokerClient | None = None,
@@ -40,6 +40,11 @@ def safe_publish(
         bidx = mqtt_client_info['broker_idx']
         broker = topics.get_broker_config(state, bidx)
         broker_name = broker.get('name', f'broker-{bidx}')
+
+        topic = topics.get_topic(state, topic_type, bidx)
+        if not topic:
+            continue
+
         try:
             broker_client = mqtt_client_info['client']
             qos = broker.get('qos', 0)
@@ -87,11 +92,10 @@ def publish_status(
 ) -> None:
     """Publish status message (NOT retained)."""
     status_msg = build_status_message(state, status, include_stats=True)
-    status_topic = topics.get_topic(state, "status", broker_idx)
-
+    
     if client:
-        safe_publish(state, status_topic, json.dumps(status_msg), retain=False, client=client, broker_idx=broker_idx)
+        safe_publish(state, "status", json.dumps(status_msg), retain=False, client=client, broker_idx=broker_idx)
     else:
-        safe_publish(state, status_topic, json.dumps(status_msg), retain=False)
+        safe_publish(state, "status", json.dumps(status_msg), retain=False)
 
     logger.debug(f"Published status: {status}")

--- a/bridge/mqtt_publish.py
+++ b/bridge/mqtt_publish.py
@@ -25,7 +25,7 @@ def safe_publish(
 ) -> bool:
     """Publish to one or all MQTT brokers."""
     if not state.mqtt_connected:
-        logger.warning(f"Not connected - skipping publish to {topic}")
+        logger.warning(f"Not connected - skipping publish to {topic_type}")
         state.stats['publish_failures'] += 1
         return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
 [project]
 name = "meshcoretomqtt"
 requires-python = ">=3.11"
+version = "0.1.0"
+dependencies = [
+    "paho-mqtt",
+    "tomli",
+    "pyserial",
+]
 
 [project.optional-dependencies]
 test = ["pytest>=7.0"]

--- a/tests/test_broker_client.py
+++ b/tests/test_broker_client.py
@@ -45,7 +45,7 @@ class TestSafePublish:
             ],
             repeater_pub_key="AA" * 32,
         )
-        result = safe_publish(state, "test/topic", '{"msg":"hello"}')
+        result = safe_publish(state, "packets", '{"msg":"hello"}')
         assert result is True
         assert len(broker1.published) == 1
         assert len(broker2.published) == 1
@@ -53,7 +53,7 @@ class TestSafePublish:
     def test_skips_when_not_connected(self):
         state = make_test_state()
         state.mqtt_connected = False
-        result = safe_publish(state, "test/topic", '{"msg":"hello"}')
+        result = safe_publish(state, "packets", '{"msg":"hello"}')
         assert result is False
         assert state.stats['publish_failures'] == 1
 
@@ -69,7 +69,7 @@ class TestSafePublish:
             ],
             repeater_pub_key="AA" * 32,
         )
-        result = safe_publish(state, "test/topic", '{"msg":"hello"}', client=broker1)
+        result = safe_publish(state, "packets", '{"msg":"hello"}', client=broker1)
         assert result is True
         assert len(broker1.published) == 1
         assert len(broker2.published) == 0
@@ -85,7 +85,7 @@ class TestSafePublish:
             broker_clients=[{"client": broker, "broker_idx": 0, "connected": True}],
             repeater_pub_key="AA" * 32,
         )
-        safe_publish(state, "test/topic", '{"msg":"hello"}')
+        safe_publish(state, "packets", '{"msg":"hello"}')
         assert broker.published[0][2] == 0  # qos forced to 0
 
 

--- a/tests/test_broker_client.py
+++ b/tests/test_broker_client.py
@@ -133,3 +133,56 @@ class TestPublishStatus:
         assert len(broker.published) == 1
         topic = broker.published[0][0]
         assert "status" in topic
+
+    def test_multi_broker_topic_resolution(self):
+        """Verify that brokers with specific topic overrides use their own templates."""
+        broker0 = FakeBrokerClient()
+        broker0._connected = True
+        broker1 = FakeBrokerClient()
+        broker1._connected = True
+
+        config = make_config(broker=[
+            {
+                'name': 'broker0',
+                'enabled': True,
+                'server': 'localhost',
+                'port': 1883,
+                'topics': {
+                    'packets': 'brokerZero/{IATA}/packet',
+                    'iata': 'B0'
+                },
+                'auth': {'method': 'none'},
+                'tls': {'enabled': False},
+            },
+            {
+                'name': 'broker1',
+                'enabled': True,
+                'server': 'localhost',
+                'port': 1884,
+                'topics': {
+                    'packets': 'brokerOne/{IATA}/packet',
+                    'iata': 'B0'
+                },
+                'auth': {'method': 'none'},
+                'tls': {'enabled': False},
+            }
+        ])
+
+        state = make_test_state(
+            config=config,
+            broker_clients=[
+                {"client": broker0, "broker_idx": 0, "connected": True},
+                {"client": broker1, "broker_idx": 1, "connected": True},
+            ],
+            repeater_pub_key="AA" * 32,
+        )
+
+        result = safe_publish(state, "packets", '{"msg":"hello"}')
+
+        assert result is True
+        assert len(broker0.published) == 1
+        assert len(broker1.published) == 1
+
+        # Check that topics were resolved correctly using broker-specific IATA
+        assert broker0.published[0][0] == "brokerZero/B0/packet"
+        assert broker1.published[0][0] == "brokerOne/B0/packet"


### PR DESCRIPTION
message_parser.py now passes the topic_type string (e.g. debug/packtets) and then mqqt_publish.py now calls topics.get_topics() when the  broker index has been retrieved.