### PR TITLE
add socket:// serial endpoint support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ The runtime codebase is a `bridge/` Python package with a thin entry point (proj
 - **`mctomqtt.py`** — Thin entry point (~45 lines). Keeps `__version__`, argparse, logging setup. Creates `MeshCoreBridge(config, debug, version)` and calls `bridge.run()`.
 
 - **`bridge/`** — Python package containing all application logic, split into focused modules:
-  - **`serial_connection.py`** — `SerialConnection` ABC + `RealSerialConnection` (device I/O with internal locking) + `connect()` factory
+  - **`serial_connection.py`** — `SerialConnection` ABC + `RealSerialConnection` (pyserial device/URL I/O with internal locking) + `connect()` factory
   - **`auth_provider.py`** — `AuthProvider` ABC + `MeshCoreAuthProvider` (wraps `auth_token.py`)
   - **`broker_client.py`** — `BrokerClient` ABC + `PahoBrokerClient` (wraps paho-mqtt)
   - **`state.py`** — `BridgeState` shared mutable state container (all ~30 instance variables)
@@ -75,6 +75,8 @@ Configuration uses TOML files with a layered override system. Python 3.11+ `toml
 **Override mechanism:** Drop-in files are deep-merged over the base config. Nested dicts are merged recursively; `[[broker]]` arrays are merged by `name` field.
 
 **Key config sections:** `[general]`, `[serial]`, `[topics]`, `[remote_serial]`, `[update]`, `[[broker]]` with nested `[broker.tls]` and `[broker.auth]`.
+
+**Serial endpoints:** `[serial].ports` uses local device paths by default. To use a TCP serial stream, add a separate `[tcp_serial]` section with `enabled = true` and `address = ["socket://host:port"]`.
 
 **Broker auth methods:** `"password"` (username/password), `"token"` (JWT from device Ed25519 key), or `"none"`.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ services.mctomqtt = {
     settings = {
       log-level = "DEBUG";
     };
+
+    # For a TCP serial stream instead of a local device:
+    # tcpSerial = {
+    #   enable = true;
+    #   address = ["socket://192.168.1.123:4403"];
+    # };
   };
 ```
 
@@ -215,6 +221,29 @@ port = 1883
 method = "password"
 username = "my_username"
 password = "my_password"
+```
+
+### Basic TCP Serial Example (00-user.toml)
+
+```toml
+[general]
+iata = "SEA"
+
+[tcp_serial]
+enabled = true
+address = ["socket://192.168.1.123:4403"]
+
+# Example MQTT broker configuration
+[[broker]]
+name = "my-tcp-mqtt"
+enabled = true
+server = "mqtt-tcp.example.com"
+port = 1883
+
+[broker.auth]
+method = "password"
+username = "tcp_username"
+password = "tcp_password"
 ```
 
 ### Advanced Example with Multiple Brokers

--- a/bridge/serial_connection.py
+++ b/bridge/serial_connection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import calendar
 import json
 import logging
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -13,6 +14,7 @@ from typing import Any
 import serial
 
 logger = logging.getLogger(__name__)
+UNSOLICITED_LOG_PATTERN = re.compile(r"^\d{2}:\d{2}:\d{2}\s+-\s+\d{1,2}/\d{1,2}/\d{4}\s+U(?:\sRAW:|:)")
 
 
 class SerialConnection(ABC):
@@ -337,7 +339,7 @@ class RealSerialConnection(SerialConnection):
         return getattr(self._port, 'is_open', False)
 
 
-def connect(config: dict[str, Any]) -> RealSerialConnection | None:
+def _connect_serial(config: dict[str, Any]) -> RealSerialConnection | None:
     """Try configured serial ports and return the first successful connection."""
     serial_cfg = config.get('serial', {})
     ports = serial_cfg.get('ports', ['/dev/ttyACM0'])
@@ -365,4 +367,417 @@ def connect(config: dict[str, Any]) -> RealSerialConnection | None:
             continue
 
     logger.error("Failed to connect to any serial port")
+    return None
+
+
+def connect(config: dict[str, Any]) -> SerialConnection | None:
+    """Choose the configured connection type and return the first successful connection."""
+    tcp_cfg = config.get('tcp_serial', {})
+    if tcp_cfg.get('enabled', False):
+        return _connect_tcp(config)
+    return _connect_serial(config)
+
+
+class TcpSerialConnection(SerialConnection):
+    """Concrete implementation for socket:// endpoints with reply buffering."""
+
+    def __init__(self, port: serial.SerialBase) -> None:
+        self._port = port
+        self._lock = threading.Lock()
+        self._last_activity = time.time()
+        self._line_buffer = bytearray()
+
+    def _send(self, cmd: str, delay: float = 0.5, allow_plain: bool = False) -> str:
+        """Send command and read response under lock."""
+        with self._lock:
+            return self._send_unlocked(cmd, delay, allow_plain=allow_plain)
+
+    def _response_timeout(self, delay: float) -> float:
+        port_timeout = getattr(self._port, 'timeout', 0)
+        if not isinstance(port_timeout, (int, float)) or port_timeout is None:
+            port_timeout = 0
+        return max(delay, float(port_timeout))
+
+    def _has_prompt(self, response: str) -> bool:
+        normalized = response.replace('\r\n', '\n').replace('\r', '\n')
+        return normalized == '> ' or normalized.endswith('\n> ')
+
+    def _is_prompt_only(self, response: str) -> bool:
+        normalized = response.replace('\r\n', '\n').replace('\r', '\n').strip()
+        return normalized == '>'
+
+    def _is_unsolicited_line(self, line: str) -> bool:
+        return bool(UNSOLICITED_LOG_PATTERN.match(line)) or line.startswith("DEBUG")
+
+    def _extract_response_value(self, response: str, command: str, allow_plain: bool = False) -> str | None:
+        normalized = response.replace('\r\n', '\n').replace('\r', '\n')
+        arrow_values: list[str] = []
+        plain_values: list[str] = []
+
+        for line in normalized.split('\n'):
+            stripped = line.strip()
+            if not stripped or stripped == '>' or stripped == command:
+                continue
+
+            if '->' in stripped:
+                value = stripped.split('->', 1)[1].strip()
+                if value.startswith('>'):
+                    value = value[1:].strip()
+                if value:
+                    arrow_values.append(value)
+                continue
+
+            if allow_plain and not self._is_unsolicited_line(stripped):
+                plain_values.append(stripped)
+
+        if arrow_values:
+            return arrow_values[-1]
+        if plain_values:
+            return plain_values[-1]
+
+        return None
+
+    def _read_response(
+        self,
+        delay: float,
+        command: str | None = None,
+        allow_plain: bool = False,
+        single_line: bool = True,
+    ) -> str:
+        deadline = time.time() + self._response_timeout(delay)
+        response_chunks: list[str] = []
+
+        while time.time() < deadline:
+            chunk = self._port.read_until(b'> ')
+            if chunk:
+                decoded = chunk.decode(errors='replace')
+                if self._is_prompt_only(decoded):
+                    continue
+
+                response_chunks.append(decoded)
+                response = ''.join(response_chunks)
+                if self._has_prompt(response):
+                    break
+                if single_line and command and self._extract_response_value(response, command, allow_plain=allow_plain):
+                    break
+            else:
+                if response_chunks:
+                    break
+                sleep(0.05)
+
+        return ''.join(response_chunks)
+
+    def _send_unlocked(
+        self,
+        cmd: str,
+        delay: float = 0.5,
+        allow_plain: bool = False,
+        single_line: bool = True,
+    ) -> str:
+        """Send command and read response (caller must hold lock)."""
+        self._line_buffer.clear()
+        self._port.reset_input_buffer()
+        self._port.reset_output_buffer()
+        self._port.write(cmd.encode())
+        return self._read_response(delay, command=cmd.strip(), allow_plain=allow_plain, single_line=single_line)
+
+    def _normalize_live_line(self, line_bytes: bytes) -> str | None:
+        line = line_bytes.decode(errors='replace').strip()
+        if line == '>':
+            return None
+        if line.startswith('> '):
+            line = line[2:].lstrip()
+        return line or None
+
+    def _extract_buffered_live_line(self) -> str | None:
+        while True:
+            newline_idx = self._line_buffer.find(b'\n')
+            if newline_idx == -1:
+                return None
+
+            line_bytes = bytes(self._line_buffer[:newline_idx])
+            del self._line_buffer[:newline_idx + 1]
+
+            line = self._normalize_live_line(line_bytes)
+            if line:
+                return line
+
+    def _read_socket_chunk(self) -> bytes:
+        original_timeout = getattr(self._port, 'timeout', None)
+        try:
+            self._port.timeout = 0
+            return self._port.read(4096)
+        finally:
+            self._port.timeout = original_timeout
+
+    def set_time(self) -> None:
+        epoch_time = int(calendar.timegm(time.gmtime()))
+        cmd = f'time {epoch_time}\r\n'
+        response = self._send(cmd)
+        logger.debug(f"Set time response: {response}")
+
+    def get_name(self) -> str | None:
+        response = self._send("get name\r\n", allow_plain=True)
+        logger.debug(f"Raw response: {response}")
+
+        name = self._extract_response_value(response, "get name", allow_plain=True)
+        if name:
+            logger.info(f"Repeater name: {name}")
+            return name
+
+        logger.error(f"Failed to get repeater name from response: {response!r}")
+        return None
+
+    def get_pubkey(self) -> str | None:
+        response = self._send("get public.key\r\n", delay=1.0, allow_plain=True)
+        logger.debug(f"Raw response: {response}")
+
+        pub_key = self._extract_response_value(response, "get public.key", allow_plain=True)
+        if pub_key:
+            pub_key_clean = pub_key.replace(' ', '').replace('\r', '').replace('\n', '')
+
+            if not pub_key_clean or len(pub_key_clean) != 64 or not all(c in '0123456789ABCDEFabcdef' for c in pub_key_clean):
+                logger.error(f"Invalid public key format: {repr(pub_key_clean)} (extracted from: {repr(pub_key)})")
+                return None
+
+            result = pub_key_clean.upper()
+            logger.info(f"Repeater pub key: {result}")
+            return result
+
+        logger.error("Failed to get repeater pub key from response")
+        return None
+
+    def get_privkey(self) -> str | None:
+        response = self._send("get prv.key\r\n", delay=1.0, allow_plain=True)
+
+        priv_key = self._extract_response_value(response, "get prv.key", allow_plain=True)
+        if priv_key:
+            priv_key_clean = priv_key.replace(' ', '').replace('\r', '').replace('\n', '')
+            if len(priv_key_clean) == 128:
+                try:
+                    int(priv_key_clean, 16)
+                    logger.info(f"Repeater priv key: {priv_key_clean[:4]}... (truncated for security)")
+                    return priv_key_clean
+                except ValueError as e:
+                    logger.error(f"Response not valid hex: {priv_key_clean[:32]}... Error: {e}")
+            else:
+                logger.error(f"Response wrong length: {len(priv_key_clean)} (expected 128)")
+
+        logger.error("Failed to get repeater priv key from response - command may not be supported by firmware")
+        return None
+
+    def get_radio_info(self) -> str | None:
+        response = self._send("get radio\r\n", allow_plain=True)
+        logger.debug(f"Raw radio response: {response}")
+
+        radio_info = self._extract_response_value(response, "get radio", allow_plain=True)
+        if radio_info:
+            logger.debug(f"Parsed radio info: {radio_info}")
+            return radio_info
+
+        logger.error("Failed to get radio info from response")
+        return None
+
+    def get_firmware_version(self) -> str | None:
+        response = self._send("ver\r\n", allow_plain=True)
+        logger.debug(f"Raw version response: {response}")
+
+        version = self._extract_response_value(response, "ver", allow_plain=True)
+        if version:
+            logger.info(f"Firmware version: {version}")
+            return version
+
+        logger.warning("Failed to get firmware version from response")
+        return None
+
+    def get_board_type(self) -> str | None:
+        response = self._send("board\r\n", allow_plain=True)
+        logger.debug(f"Raw board response: {response}")
+
+        board_type = self._extract_response_value(response, "board", allow_plain=True)
+        if board_type:
+            if board_type == "Unknown command":
+                board_type = "unknown"
+            logger.info(f"Board type: {board_type}")
+            return board_type
+
+        logger.warning("Failed to get board type from response")
+        return None
+
+    def get_device_stats(self) -> dict[str, Any]:
+        stats: dict[str, Any] = {}
+
+        with self._lock:
+            # stats-core: battery_mv, uptime_secs, errors, queue_len
+            response = self._send_unlocked("stats-core\r\n")
+            logger.debug(f"Raw stats-core response: {response}")
+
+            if "-> " in response and "Unknown command" not in response:
+                try:
+                    json_str = response.split("-> ", 1)[1].strip()
+                    json_str = json_str.split('\n')[0].replace('\r', '').strip()
+                    core_stats = json.loads(json_str)
+                    if 'battery_mv' in core_stats:
+                        stats['battery_mv'] = core_stats['battery_mv']
+                    if 'uptime_secs' in core_stats:
+                        stats['uptime_secs'] = core_stats['uptime_secs']
+                    if 'errors' in core_stats:
+                        stats['debug_flags'] = core_stats['errors']
+                    if 'queue_len' in core_stats:
+                        stats['queue_len'] = core_stats['queue_len']
+                except (json.JSONDecodeError, ValueError) as e:
+                    logger.debug(f"Failed to parse stats-core: {e}")
+
+            # stats-radio: noise_floor, tx_air_secs, rx_air_secs
+            response = self._send_unlocked("stats-radio\r\n")
+            logger.debug(f"Raw stats-radio response: {response}")
+
+            if "-> " in response and "Unknown command" not in response:
+                try:
+                    json_str = response.split("-> ", 1)[1].strip()
+                    json_str = json_str.split('\n')[0].replace('\r', '').strip()
+                    radio_stats = json.loads(json_str)
+                    if 'noise_floor' in radio_stats:
+                        stats['noise_floor'] = radio_stats['noise_floor']
+                    if 'tx_air_secs' in radio_stats:
+                        stats['tx_air_secs'] = radio_stats['tx_air_secs']
+                    if 'rx_air_secs' in radio_stats:
+                        stats['rx_air_secs'] = radio_stats['rx_air_secs']
+                except (json.JSONDecodeError, ValueError) as e:
+                    logger.debug(f"Failed to parse stats-radio: {e}")
+
+            # stats-packets: recv_errors
+            response = self._send_unlocked("stats-packets\r\n")
+            logger.debug(f"Raw stats-packets response: {response}")
+
+            if "-> " in response and "Unknown command" not in response:
+                try:
+                    json_str = response.split("-> ", 1)[1].strip()
+                    json_str = json_str.split('\n')[0].replace('\r', '').strip()
+                    packets_stats: dict[str, Any] = json.loads(json_str)
+                    if 'recv_errors' in packets_stats:
+                        stats['recv_errors'] = packets_stats['recv_errors']
+                except (json.JSONDecodeError, ValueError) as e:
+                    logger.debug(f"Failed to parse stats-packets: {e}")
+
+        if stats:
+            self._last_activity = time.time()
+
+        return stats
+
+    def execute_command(self, command: str, timeout: float = 10.0) -> tuple[bool, str]:
+        try:
+            with self._lock:
+                self._line_buffer.clear()
+                self._port.reset_input_buffer()
+                self._port.reset_output_buffer()
+
+                cmd_bytes = command.strip()
+                if not cmd_bytes.endswith('\r\n'):
+                    cmd_bytes += '\r\n'
+
+                self._port.write(cmd_bytes.encode('utf-8'))
+                logger.debug(f"[SERIAL] Sent: {command.strip()}")
+                full_response = self._read_response(timeout, single_line=False)
+
+                if "-> >" in full_response:
+                    response_text = full_response.split("-> >")[1].strip()
+                elif "-> " in full_response:
+                    response_text = full_response.split("-> ", 1)[1].strip()
+                elif "> " in full_response:
+                    response_text = full_response.split("> ", 1)[1].strip()
+                else:
+                    response_text = full_response.strip()
+
+                if response_text.startswith(command.strip()):
+                    response_text = response_text[len(command.strip()):].strip()
+
+                response_text = response_text.rstrip('> ').strip()
+
+                if not response_text:
+                    response_text = "(no output)"
+
+                logger.debug(f"[SERIAL] Response: {response_text[:100]}{'...' if len(response_text) > 100 else ''}")
+                return True, response_text
+
+        except serial.SerialException as e:
+            logger.error(f"[SERIAL] Serial error executing command: {e}")
+            return False, f"Serial error: {str(e)}"
+        except Exception as e:
+            logger.error(f"[SERIAL] Error executing command: {e}")
+            return False, f"Error: {str(e)}"
+
+    def read_line(self) -> str | None:
+        with self._lock:
+            line = self._extract_buffered_live_line()
+            if line:
+                self._last_activity = time.time()
+                return line
+
+            try:
+                while self._port.in_waiting > 0:
+                    chunk = self._read_socket_chunk()
+                    if not chunk:
+                        break
+                    self._line_buffer.extend(chunk)
+                    line = self._extract_buffered_live_line()
+                    if line:
+                        self._last_activity = time.time()
+                        return line
+            except serial.SerialException as e:
+                raise OSError(str(e)) from e
+        return None
+
+    def seconds_since_activity(self) -> float:
+        return time.time() - self._last_activity
+
+    def close(self) -> None:
+        try:
+            with self._lock:
+                if self._port and getattr(self._port, 'is_open', False):
+                    logger.debug("Closing serial connection")
+                    self._port.close()
+        except Exception:
+            pass
+
+    @property
+    def is_open(self) -> bool:
+        return getattr(self._port, 'is_open', False)
+
+
+def _connect_tcp(config: dict[str, Any]) -> TcpSerialConnection | None:
+    """Try configured TCP endpoints and return the first successful connection."""
+    tcp_cfg = config.get('tcp_serial', {})
+    serial_cfg = config.get('serial', {})
+    configured_addresses = tcp_cfg.get('address', [])
+
+    if isinstance(configured_addresses, str):
+        addresses = [configured_addresses.strip()] if configured_addresses.strip() else []
+    else:
+        addresses = [str(address).strip() for address in configured_addresses if str(address).strip()]
+
+    if not addresses:
+        logger.error("TCP serial is enabled but no address is configured")
+        return None
+
+    for address in addresses:
+        try:
+            ser = serial.serial_for_url(
+                address,
+                baudrate=serial_cfg.get('baud_rate', 115200),
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                bytesize=serial.EIGHTBITS,
+                timeout=serial_cfg.get('timeout', 2),
+                rtscts=False
+            )
+            ser.reset_input_buffer()
+            ser.reset_output_buffer()
+            logger.info(f"Connected to {address}")
+            return TcpSerialConnection(ser)
+        except (serial.SerialException, OSError) as e:
+            logger.warning(f"Failed to connect to {address}: {str(e)}")
+            continue
+
+    logger.error("Failed to connect to any configured TCP endpoint")
     return None

--- a/config.toml.example
+++ b/config.toml.example
@@ -36,6 +36,11 @@ timeout = 2
 # Watchdog: seconds with no data before forcing serial reconnect (0 to disable)
 watchdog_timeout = 900
 
+[tcp_serial]
+# Addresses for serial TCP stream (using socket://host:port)
+enabled = false
+address = [""]
+
 [topics]
 # Topic templates - supported variables: {IATA}, {PUBLIC_KEY}
 status = "meshcore/{IATA}/{PUBLIC_KEY}/status"

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -90,6 +90,12 @@
     syncTime = cfg.settings.sync-time or true;
     serialBaudRate = cfg.settings.serial-baud-rate or 115200;
     serialTimeout = cfg.settings.serial-timeout or 2;
+    tcpSerialEnabled = cfg.tcpSerial.enable;
+    tcpSerialAddress = cfg.tcpSerial.address;
+    serialDevicePaths =
+      if tcpSerialEnabled
+      then []
+      else lib.filter (port: lib.hasPrefix "/dev/" port) cfg.serialPorts;
 
     # Build the full TOML config structure
     tomlConfig = {
@@ -99,10 +105,16 @@
         sync_time = syncTime;
       };
 
-      serial = {
-        ports = cfg.serialPorts;
-        baud_rate = serialBaudRate;
-        timeout = serialTimeout;
+      serial =
+        {
+          ports = cfg.serialPorts;
+          baud_rate = serialBaudRate;
+          timeout = serialTimeout;
+        };
+
+      tcp_serial = {
+        enabled = tcpSerialEnabled;
+        address = tcpSerialAddress;
       };
 
       topics = {
@@ -148,6 +160,21 @@
         default = ["/dev/ttyACM0"];
         description = "Serial ports to listen on (will be available to the mctomqtt user)";
         example = ["/dev/ttyACM0" "/dev/ttyACM1"];
+      };
+
+      tcpSerial = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Use a TCP serial stream instead of local serial ports";
+        };
+
+        address = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [];
+          example = ["socket://192.168.1.123:4403"];
+          description = "TCP serial stream addresses";
+        };
       };
 
       brokers = lib.mkOption {
@@ -212,6 +239,10 @@
           assertion = cfg.package != null;
           message = "mctomqtt package not found. Either set services.mctomqtt.package or ensure the flake outputs a package for system ${pkgs.system}";
         }
+        {
+          assertion = (!cfg.tcpSerial.enable) || (cfg.tcpSerial.address != []);
+          message = "services.mctomqtt.tcpSerial.address must be set when tcpSerial.enable is true";
+        }
       ];
       # Create system user and group
       users.users.mctomqtt = {
@@ -252,12 +283,12 @@
               "/var/cache/mctomqtt"
               "/var/log/mctomqtt"
             ]
-            ++ cfg.serialPorts;
+            ++ serialDevicePaths;
         };
 
-        # Ensure serial devices are available
-        requires = map (port: "dev-${lib.replaceStrings ["/dev/"] [""] port}.device") cfg.serialPorts;
-        after = ["network.target"] ++ map (port: "dev-${lib.replaceStrings ["/dev/"] [""] port}.device") cfg.serialPorts;
+        # Ensure local serial devices are available
+        requires = map (port: "dev-${lib.replaceStrings ["/dev/"] [""] port}.device") serialDevicePaths;
+        after = ["network.target"] ++ map (port: "dev-${lib.replaceStrings ["/dev/"] [""] port}.device") serialDevicePaths;
       };
     };
   };

--- a/nix/nixos-test.nix
+++ b/nix/nixos-test.nix
@@ -58,6 +58,31 @@
         };
       };
 
+      nodes.tcpMachine = {
+        config,
+        pkgs,
+        ...
+      }: {
+        imports = [self.nixosModules.default];
+
+        services.mctomqtt = {
+          enable = true;
+          package = mockMctomqtt;
+          iata = "TCP";
+          defaults.letsmesh-us.enable = false;
+          defaults.letsmesh-eu.enable = false;
+
+          tcpSerial = {
+            enable = true;
+            address = ["socket://192.168.1.123:4403"];
+          };
+
+          settings = {
+            log-level = "INFO";
+          };
+        };
+      };
+
       testScript = ''
         import tomllib
 
@@ -157,6 +182,31 @@
             machine.succeed("systemctl restart mctomqtt.service")
             machine.wait_for_unit("mctomqtt.service")
             machine.succeed("systemctl is-active --quiet mctomqtt.service")
+
+        # Wait for the TCP-configured service to start
+        tcpMachine.wait_for_unit("mctomqtt.service")
+        tcpMachine.succeed("systemctl is-active --quiet mctomqtt.service")
+
+        # Extract config file path from the TCP systemd unit
+        tcp_unit_content = tcpMachine.succeed("systemctl cat mctomqtt.service")
+        tcp_config_path = None
+        for line in tcp_unit_content.splitlines():
+            if "--config" in line:
+                tcp_config_path = line.split("--config")[1].strip().split()[0].rstrip(";")
+                break
+        assert tcp_config_path is not None, "Could not find --config in TCP ExecStart"
+
+        # Read and parse the generated TCP TOML config
+        tcp_config_toml = tcpMachine.succeed(f"cat {tcp_config_path}")
+        tcp_config = tomllib.loads(tcp_config_toml)
+
+        with subtest("TCP serial section"):
+            assert tcp_config["tcp_serial"]["enabled"] is True
+            assert tcp_config["tcp_serial"]["address"] == ["socket://192.168.1.123:4403"]
+
+        with subtest("TCP service does not depend on a local serial device"):
+            tcpMachine.fail("systemctl show mctomqtt.service | grep 'After=' | grep -q 'dev-ttyACM0.device'")
+            tcpMachine.fail("systemctl show mctomqtt.service | grep 'Requires=' | grep -q 'dev-ttyACM0.device'")
 
         print("All tests passed!")
       '';

--- a/tests/test_tcp_serial_connection.py
+++ b/tests/test_tcp_serial_connection.py
@@ -1,0 +1,278 @@
+"""Tests for TcpSerialConnection behavior with mock socket-backed serial ports."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import serial
+
+from bridge.serial_connection import RealSerialConnection, TcpSerialConnection, connect
+
+
+def _make_tcp_conn(read_until_value: bytes | list[bytes] = b"") -> tuple[TcpSerialConnection, MagicMock]:
+    """Create a TcpSerialConnection with a mock socket-backed serial port."""
+    mock_port = MagicMock(spec=serial.Serial)
+    mock_port.is_open = True
+    mock_port.timeout = 2
+    mock_port.portstr = "socket://192.168.1.123:4403"
+    if isinstance(read_until_value, list):
+        mock_port.read_until.side_effect = read_until_value
+    else:
+        mock_port.read_until.return_value = read_until_value
+    conn = TcpSerialConnection(mock_port)
+    return conn, mock_port
+
+
+class TestTcpGetName:
+    def test_parses_bare_value_response(self):
+        conn, _ = _make_tcp_conn(b"TestNode\n")
+        assert conn.get_name() == "TestNode"
+
+    def test_parses_arrow_response(self):
+        conn, _ = _make_tcp_conn(b"get name\n  -> >MyRepeater\n> ")
+        assert conn.get_name() == "MyRepeater"
+
+    def test_parses_arrow_response_without_prompt_marker(self):
+        conn, _ = _make_tcp_conn(b"get name\n  -> MyRepeater\n> ")
+        assert conn.get_name() == "MyRepeater"
+
+    def test_waits_for_delayed_response(self):
+        conn, _ = _make_tcp_conn([
+            b"",
+            b"get name\n  ->",
+            b" >DelayedNode\n",
+            b"> ",
+        ])
+        assert conn.get_name() == "DelayedNode"
+
+    def test_ignores_prompt_only_before_response(self):
+        conn, _ = _make_tcp_conn([
+            b"> ",
+            b"get name\n  -> MeshNode\n> ",
+        ])
+        assert conn.get_name() == "MeshNode"
+
+    def test_ignores_unsolicited_line_before_reply(self):
+        conn, _ = _make_tcp_conn([
+            b"12:34:56 - 22/4/2026 U: RX, len=12 (type=5, route=F, payload_len=8)\n",
+            b"get name\n  -> MeshNode\n> ",
+        ])
+        assert conn.get_name() == "MeshNode"
+
+    def test_ignores_unsolicited_line_before_bare_reply(self):
+        conn, _ = _make_tcp_conn([
+            b"12:34:56 - 22/4/2026 U: RX, len=12 (type=5, route=F, payload_len=8)\n",
+            b"TestNode\n",
+        ])
+        assert conn.get_name() == "TestNode"
+
+
+class TestTcpGetPubkey:
+    def test_valid_64_hex_bare_value(self):
+        key = "aa" * 32
+        conn, _ = _make_tcp_conn(f"{key}\n".encode())
+        assert conn.get_pubkey() == key.upper()
+
+    def test_valid_64_hex_without_prompt_marker(self):
+        key = "aa" * 32
+        conn, _ = _make_tcp_conn(f"get public.key\n  -> {key}\n> ".encode())
+        assert conn.get_pubkey() == key.upper()
+
+
+class TestTcpGetFirmwareVersion:
+    def test_ignores_unsolicited_line_before_reply(self):
+        conn, _ = _make_tcp_conn([
+            b"12:34:56 - 22/4/2026 U RAW: 0A1B2C3D\n",
+            b"ver\n  -> 1.8.2-dev-834c700 (Build: 04-Sep-2025)\n> ",
+        ])
+        assert conn.get_firmware_version() == "1.8.2-dev-834c700 (Build: 04-Sep-2025)"
+
+
+class TestTcpExecuteCommand:
+    def test_success(self):
+        mock_port = MagicMock(spec=serial.Serial)
+        mock_port.is_open = True
+        mock_port.timeout = 2
+        mock_port.portstr = "socket://192.168.1.123:4403"
+        mock_port.read_until.return_value = b"ver\n  -> 1.8.2\n> "
+        conn = TcpSerialConnection(mock_port)
+        success, response = conn.execute_command("ver")
+        assert success is True
+        assert "1.8.2" in response
+
+
+class TestTcpReadLine:
+    def test_socket_accumulates_chunked_line_across_reads(self):
+        mock_port = MagicMock(spec=serial.Serial)
+        mock_port.is_open = True
+        mock_port.timeout = 2
+        mock_port.portstr = "socket://192.168.1.123:4403"
+        mock_port.in_waiting = 1
+        mock_port.read.side_effect = [
+            b"12:34:56 - 1/15/2025 U: RX, len=32 ",
+            b"",
+            b"(type=2, route=F, payload_len=16)\n",
+        ]
+        conn = TcpSerialConnection(mock_port)
+
+        assert conn.read_line() is None
+        assert conn.read_line() == "12:34:56 - 1/15/2025 U: RX, len=32 (type=2, route=F, payload_len=16)"
+
+    def test_strips_leading_prompt_from_live_line(self):
+        mock_port = MagicMock(spec=serial.Serial)
+        mock_port.is_open = True
+        mock_port.timeout = 2
+        mock_port.portstr = "socket://192.168.1.123:4403"
+        mock_port.in_waiting = 10
+        mock_port.read.return_value = b"> 12:34:56 - 1/15/2025 U: RX, len=32 (type=2, route=F, payload_len=16)\n"
+        conn = TcpSerialConnection(mock_port)
+        assert conn.read_line() == "12:34:56 - 1/15/2025 U: RX, len=32 (type=2, route=F, payload_len=16)"
+
+    def test_ignores_prompt_only_line(self):
+        mock_port = MagicMock(spec=serial.Serial)
+        mock_port.is_open = True
+        mock_port.timeout = 2
+        mock_port.portstr = "socket://192.168.1.123:4403"
+        mock_port.in_waiting = 2
+        mock_port.read.side_effect = [b"> \n", b""]
+        conn = TcpSerialConnection(mock_port)
+        assert conn.read_line() is None
+
+
+class TestTcpConnectFactory:
+    def test_uses_tcp_connection_when_enabled(self, monkeypatch):
+        config = {
+            'serial': {
+                'baud_rate': 115200,
+                'timeout': 2,
+            },
+            'tcp_serial': {
+                'enabled': True,
+                'address': ['socket://192.168.1.123:4403'],
+            },
+        }
+        mock_port = MagicMock()
+        mock_port.is_open = True
+        urls: list[str] = []
+
+        def fake_serial_for_url(url, *args, **kwargs):
+            urls.append(url)
+            return mock_port
+
+        monkeypatch.setattr(serial, 'serial_for_url', fake_serial_for_url)
+
+        result = connect(config)
+
+        assert isinstance(result, TcpSerialConnection)
+        assert urls == ['socket://192.168.1.123:4403']
+        mock_port.write.assert_not_called()
+
+    def test_returns_none_when_all_tcp_endpoints_fail(self, monkeypatch):
+        config = {
+            'serial': {
+                'baud_rate': 115200,
+                'timeout': 2,
+            },
+            'tcp_serial': {
+                'enabled': True,
+                'address': ['socket://192.168.1.123:4403'],
+            },
+        }
+
+        def fake_serial_for_url(*args, **kwargs):
+            raise serial.SerialException("nope")
+
+        monkeypatch.setattr(serial, 'serial_for_url', fake_serial_for_url)
+
+        result = connect(config)
+        assert result is None
+
+    def test_returns_none_when_tcp_enabled_without_address(self):
+        config = {
+            'serial': {
+                'baud_rate': 115200,
+                'timeout': 2,
+            },
+            'tcp_serial': {
+                'enabled': True,
+                'address': [],
+            },
+        }
+
+        result = connect(config)
+        assert result is None
+
+    def test_does_not_fallback_to_serial_when_tcp_enabled(self, monkeypatch):
+        config = {
+            'serial': {
+                'ports': ['/dev/ttyACM0'],
+                'baud_rate': 115200,
+                'timeout': 2,
+            },
+            'tcp_serial': {
+                'enabled': True,
+                'address': ['socket://192.168.1.123:4403'],
+            },
+        }
+
+        def fake_serial(*args, **kwargs):
+            raise AssertionError("Serial fallback should not be attempted")
+
+        def fake_serial_for_url(*args, **kwargs):
+            raise serial.SerialException("nope")
+
+        monkeypatch.setattr(serial, 'Serial', fake_serial)
+        monkeypatch.setattr(serial, 'serial_for_url', fake_serial_for_url)
+
+        result = connect(config)
+        assert result is None
+
+
+class TestConnectFactoryDefaults:
+    def test_serial_remains_default_when_tcp_disabled(self, monkeypatch):
+        config = {
+            'serial': {
+                'ports': ['/dev/ttyACM0'],
+                'baud_rate': 115200,
+                'timeout': 2,
+            },
+            'tcp_serial': {
+                'enabled': False,
+                'address': ['socket://192.168.1.123:4403'],
+            },
+        }
+        mock_port = MagicMock(spec=serial.Serial)
+        mock_port.is_open = True
+
+        def fake_serial(*args, **kwargs):
+            return mock_port
+
+        monkeypatch.setattr(serial, 'Serial', fake_serial)
+
+        result = connect(config)
+        assert isinstance(result, RealSerialConnection)
+
+    def test_accepts_legacy_string_address(self, monkeypatch):
+        config = {
+            'serial': {
+                'baud_rate': 115200,
+                'timeout': 2,
+            },
+            'tcp_serial': {
+                'enabled': True,
+                'address': 'socket://192.168.1.123:4403',
+            },
+        }
+        mock_port = MagicMock()
+        mock_port.is_open = True
+        urls: list[str] = []
+
+        def fake_serial_for_url(url, *args, **kwargs):
+            urls.append(url)
+            return mock_port
+
+        monkeypatch.setattr(serial, 'serial_for_url', fake_serial_for_url)
+
+        result = connect(config)
+
+        assert isinstance(result, TcpSerialConnection)
+        assert urls == ['socket://192.168.1.123:4403']


### PR DESCRIPTION
This adds support for MeshCore nodes exposed over a raw TCP socket by allowing pyserial URLs like socket://host:port in the existing serial.ports config.

To make socket endpoints reliable, the request/reply path was also tightened up to handle delayed or chunked responses, ignore stray prompt-only reads, and avoid treating unrelated console output as command replies. Live socket reads are buffered so TCP-fragmented packet lines are reassembled before parsing.

Current local serial configs continue to work as before, and the NixOS module was updated so socket endpoints are not treated like /dev/... devices.

Validated with targeted tests, tested on hardware. Could do with more testing due to the changes to requests/replys.