### PR TITLE
Generalize the "LetsMesh" broker support into a "Load Preset" feature.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ python3 mctomqtt.py --config config.toml.example --debug    # enables DEBUG-leve
 ```bash
 docker build -t mctomqtt:latest .
 docker run -d --name mctomqtt --device=/dev/ttyACM0 \
-  -v /path/to/config.toml:/etc/mctomqtt/config.toml \
+  -v /path/to/mctomqtt-config:/etc/mctomqtt:ro \
   mctomqtt:latest
 ```
 
@@ -68,7 +68,8 @@ Configuration uses TOML files with a layered override system. Python 3.11+ `toml
 
 **Default config loading** (no `--config` flags):
 1. `/etc/mctomqtt/config.toml` (base defaults, overwritten on updates)
-2. `/etc/mctomqtt/config.d/*.toml` (drop-in overrides, alphabetical order)
+2. `/etc/mctomqtt/config.d/10-*.toml` (broker presets selected during install)
+3. `/etc/mctomqtt/config.d/99-user.toml` (local user overrides, loaded last)
 
 **`--config` override:** When one or more `--config <path>` flags are provided, default config loading is completely bypassed. Only the specified files are loaded, in order, each overlaying the previous. Multiple `--config` flags are supported for layered overrides.
 
@@ -77,6 +78,8 @@ Configuration uses TOML files with a layered override system. Python 3.11+ `toml
 **Key config sections:** `[general]`, `[serial]`, `[topics]`, `[remote_serial]`, `[update]`, `[[broker]]` with nested `[broker.tls]` and `[broker.auth]`.
 
 **Broker auth methods:** `"password"` (username/password), `"token"` (JWT from device Ed25519 key), or `"none"`.
+
+**Broker presets:** Community broker presets live in repo `presets/` as TOML files with `[[broker]]` blocks. The installer copies selected or imported presets to `/etc/mctomqtt/config.d/10-<preset>.toml`.
 
 See `config.toml.example` for the full reference with all options and defaults.
 
@@ -94,7 +97,8 @@ See `config.toml.example` for the full reference with all options and defaults.
 /etc/mctomqtt/              # Config (owned root:mctomqtt, 750)
   config.toml               # Defaults (640, overwritten on updates)
   config.d/
-    00-user.toml            # User config (640, never overwritten)
+    10-*.toml               # Broker presets
+    99-user.toml            # User config (640, never overwritten)
 ```
 
 ## Key Patterns

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,8 @@ RUN apk add --no-cache --virtual .build-deps \
 COPY ./mctomqtt.py ./auth_token.py ./config_loader.py /opt/mctomqtt/
 COPY ./bridge/ /opt/mctomqtt/bridge/
 
-# Note: Mount your config as a volume:
-#   -v /path/to/config.toml:/etc/mctomqtt/config.toml
-# Or mount a drop-in override:
-#   -v /path/to/00-user.toml:/etc/mctomqtt/config.d/00-user.toml
+# Note: Mount your config directory as a volume:
+#   -v /path/to/mctomqtt-config:/etc/mctomqtt:ro
 
 RUN adduser -D mctomqtt
 RUN addgroup mctomqtt dialout

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Pull requests automatically run the GitHub Actions test workflow on Ubuntu. That
 /etc/mctomqtt/              # Config (owned root:mctomqtt, 755)
   config.toml               # Defaults (644, OVERWRITTEN on updates)
   config.d/                 # Drop-in override directory
-    00-user.toml               # User config (644, never overwritten)
+    10-letsmesh.toml        # Optional broker preset selected during install
+    99-user.toml            # User config (644, never overwritten)
 ```
 
 ## Configuration
@@ -177,9 +178,12 @@ Pull requests automatically run the GitHub Actions test workflow on Ubuntu. That
 Configuration uses TOML files with a layered override system:
 
 - `/etc/mctomqtt/config.toml` — Default values (overwritten on updates, do not edit)
-- `/etc/mctomqtt/config.d/00-user.toml` — Your custom configuration (never overwritten)
+- `/etc/mctomqtt/config.d/10-*.toml` — Broker presets selected during install
+- `/etc/mctomqtt/config.d/99-user.toml` — Your custom configuration (never overwritten)
 
 Files in `config.d/` are loaded alphabetically and deep-merged over the defaults.
+The installer writes presets with a `10-` prefix and user overrides to
+`99-user.toml` so local settings load last.
 
 To bypass the default config loading entirely, use `--config`:
 
@@ -193,10 +197,17 @@ When `--config` is used, `/etc/mctomqtt/` is not read. Multiple `--config` flags
 ### Editing Configuration
 
 ```bash
-sudo nano /etc/mctomqtt/config.d/00-user.toml
+sudo nano /etc/mctomqtt/config.d/99-user.toml
 ```
 
-### Basic Example (00-user.toml)
+### Broker Presets
+
+The installer can copy broker presets from the repo `presets/` directory or
+import a preset from a TOML URL/local path. Selected presets are installed as
+`/etc/mctomqtt/config.d/10-<preset>.toml`; user-specific overrides remain in
+`99-user.toml`.
+
+### Basic Example (99-user.toml)
 
 ```toml
 [general]
@@ -413,7 +424,7 @@ docker build -t mctomqtt:latest /path/to/meshcoretomqtt
 docker run -d \
   --name mctomqtt \
   --restart unless-stopped \
-  -v /path/to/config.toml:/etc/mctomqtt/config.toml \
+  -v /path/to/mctomqtt-config:/etc/mctomqtt:ro \
   --device=/dev/ttyACM0 \
   mctomqtt:latest
 ```
@@ -457,7 +468,7 @@ The updater will:
 - Stop the service/container
 - Download and verify updated files
 - Overwrite `/etc/mctomqtt/config.toml` with latest defaults
-- Preserve your `/etc/mctomqtt/config.d/00-user.toml` configuration
+- Preserve your `/etc/mctomqtt/config.d/99-user.toml` configuration
 - Restart the service/container automatically
 
 ## Migration
@@ -483,7 +494,7 @@ curl -fsSL https://raw.githubusercontent.com/Cisien/meshcoretomqtt/main/uninstal
 The uninstaller will:
 
 - Stop and remove the service
-- Offer to backup your `00-user.toml` configuration
+- Offer to backup your `99-user.toml` configuration
 - Remove `/opt/mctomqtt/` and `/etc/mctomqtt/`
 - Remove the `mctomqtt` system user
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -5,9 +5,10 @@
 #
 # Config loading order (default):
 #   1. /etc/mctomqtt/config.toml          (base defaults, overwritten on updates)
-#   2. /etc/mctomqtt/config.d/*.toml      (drop-in overrides, alphabetical order)
+#   2. /etc/mctomqtt/config.d/10-*.toml   (broker presets)
+#   3. /etc/mctomqtt/config.d/99-user.toml (local overrides, loaded last)
 #
-# Put your customizations in /etc/mctomqtt/config.d/00-user.toml
+# Put your customizations in /etc/mctomqtt/config.d/99-user.toml
 #
 # The --config flag bypasses default loading entirely. Multiple --config flags
 # are supported; files are loaded in order, each overlaying the previous.
@@ -87,51 +88,8 @@ branch = "main"
 #   "token"    - MeshCore auth token (JWT from device Ed25519 key)
 #   "none"     - anonymous connection
 
-# --- LetsMesh US broker with auth token ---
-[[broker]]
-name = "letsmesh-us"
-enabled = true
-server = "mqtt-us-v1.letsmesh.net"
-port = 443
-transport = "websockets"
-keepalive = 60
-qos = 0
-retain = true
-
-[broker.tls]
-enabled = true
-verify = true
-
-[broker.auth]
-method = "token"
-audience = "mqtt-us-v1.letsmesh.net"
-# owner: public key of the owner's MeshCore companion device (64 hex chars)
-owner = ""
-# email: your LetsMesh.net account email address
-email = ""
-
-# --- LetsMesh EU broker with auth token ---
-[[broker]]
-name = "letsmesh-eu"
-enabled = true
-server = "mqtt-eu-v1.letsmesh.net"
-port = 443
-transport = "websockets"
-keepalive = 60
-qos = 0
-retain = true
-
-[broker.tls]
-enabled = true
-verify = true
-
-[broker.auth]
-method = "token"
-audience = "mqtt-eu-v1.letsmesh.net"
-# owner: public key of the owner's MeshCore companion device (64 hex chars)
-owner = ""
-# email: your LetsMesh.net account email address
-email = ""
+# Broker presets selected by the installer are copied into config.d as
+# 10-<preset>.toml. The bundled LetsMesh preset lives in repo presets/.
 
 # =============================================================================
 # Example: Local MQTT broker with username/password

--- a/installer/__main__.py
+++ b/installer/__main__.py
@@ -20,7 +20,7 @@ def main() -> None:
     sub = parser.add_subparsers(dest="command")
 
     install_p = sub.add_parser("install", help="Fresh installation")
-    install_p.add_argument("--config", dest="config_url", default="", help="URL to download 00-user.toml from")
+    install_p.add_argument("--config", dest="config_url", default="", help="URL to download 99-user.toml from")
     install_p.add_argument("--update", action="store_true", help="Non-interactive update mode")
 
     sub.add_parser("update", help="Update existing installation")

--- a/installer/config.py
+++ b/installer/config.py
@@ -283,31 +283,25 @@ def _rewrite_token_owner_overrides_toml(
 ) -> None:
     """Replace local auth metadata overrides for the given brokers."""
     path = Path(dest)
-    data: dict[str, Any] = {}
-    if path.exists():
-        with open(path, "rb") as f:
-            data = tomllib.load(f)
+    data = _load_user_toml(path)
 
-    brokers = data.get("broker", [])
+    brokers = data.get("broker")
     if not isinstance(brokers, list):
         brokers = []
+        data["broker"] = brokers
 
-    by_name: dict[str, dict[str, Any]] = {}
-    ordered: list[dict[str, Any]] = []
-    for broker in brokers:
-        if not isinstance(broker, dict):
-            continue
-        name = broker.get("name")
-        if isinstance(name, str):
-            by_name[name] = broker
-        ordered.append(broker)
+    by_name: dict[str, dict[str, Any]] = {
+        broker["name"]: broker
+        for broker in brokers
+        if isinstance(broker, dict) and isinstance(broker.get("name"), str)
+    }
 
     for broker_name in broker_names:
         broker = by_name.get(broker_name)
         if broker is None:
             broker = {"name": broker_name}
             by_name[broker_name] = broker
-            ordered.append(broker)
+            brokers.append(broker)
         auth = broker.get("auth")
         if not isinstance(auth, dict):
             auth = {}
@@ -321,8 +315,7 @@ def _rewrite_token_owner_overrides_toml(
         else:
             auth.pop("email", None)
 
-    content = _toml_dumps_user_config(data, ordered)
-    path.write_text(content)
+    _write_user_toml(path, data)
 
 
 def _remove_broker_overrides_toml(dest: str | Path, broker_names: list[str]) -> None:
@@ -331,68 +324,174 @@ def _remove_broker_overrides_toml(dest: str | Path, broker_names: list[str]) -> 
     if not path.exists():
         return
 
-    with open(path, "rb") as f:
-        data = tomllib.load(f)
+    data = _load_user_toml(path)
 
-    brokers = data.get("broker", [])
+    brokers = data.get("broker")
     if not isinstance(brokers, list):
         return
 
     remove_names = set(broker_names)
-    kept = [
+    data["broker"] = [
         broker for broker in brokers
         if not isinstance(broker, dict) or broker.get("name") not in remove_names
     ]
-    content = _toml_dumps_user_config(data, kept)
-    path.write_text(content)
+    _write_user_toml(path, data)
 
 
-def _toml_dumps_user_config(data: dict[str, Any], brokers: list[dict[str, Any]]) -> str:
-    """Serialize installer-managed user config TOML."""
-    lines = [
-        "# MeshCore to MQTT - User Configuration",
-        "# This file contains your local overrides to the defaults in config.toml",
-        "",
-    ]
+USER_CONFIG_HEADER = (
+    "# MeshCore to MQTT - User Configuration\n"
+    "# This file contains your local overrides to the defaults in config.toml\n\n"
+)
 
-    for section in ("general", "serial", "update", "remote_serial"):
-        value = data.get(section)
-        if isinstance(value, dict):
-            lines.append(f"[{section}]")
-            for key, item in value.items():
-                lines.append(f"{key} = {_toml_value(item)}")
-            lines.append("")
 
-    for broker in brokers:
-        name = broker.get("name")
-        if not isinstance(name, str):
-            continue
-        lines.append("[[broker]]")
-        lines.append(f'name = "{toml_escape(name)}"')
-        for key, item in broker.items():
-            if key in ("name", "auth", "tls", "topics") or isinstance(item, dict):
-                continue
-            lines.append(f"{key} = {_toml_value(item)}")
-        for nested in ("tls", "auth", "topics"):
-            nested_data = broker.get(nested)
-            if isinstance(nested_data, dict):
-                lines.append("")
-                lines.append(f"[broker.{nested}]")
-                for key, item in nested_data.items():
-                    lines.append(f"{key} = {_toml_value(item)}")
-        lines.append("")
+def _load_user_toml(path: str | Path) -> dict[str, Any]:
+    """Load a user TOML file, returning an empty dict if it doesn't exist."""
+    p = Path(path)
+    if not p.exists():
+        return {}
+    with open(p, "rb") as f:
+        return tomllib.load(f)
 
-    return "\n".join(lines).rstrip() + "\n"
+
+def _write_user_toml(path: str | Path, data: dict[str, Any]) -> None:
+    """Serialize a user TOML document, prepending the standard header."""
+    Path(path).write_text(USER_CONFIG_HEADER + _toml_dumps(data))
+
+
+_BARE_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _toml_key(key: str) -> str:
+    """Render a TOML key, quoting if it can't be a bare key."""
+    if _BARE_KEY_RE.match(key):
+        return key
+    return f'"{toml_escape(key)}"'
 
 
 def _toml_value(value: Any) -> str:
+    """Render a single TOML scalar/array value."""
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, int | float):
+    if isinstance(value, int):
         return str(value)
+    if isinstance(value, float):
+        return repr(value)
+    if isinstance(value, str):
+        return f'"{toml_escape(value)}"'
     if isinstance(value, list):
         return "[" + ", ".join(_toml_value(item) for item in value) + "]"
-    return f'"{toml_escape(str(value))}"'
+    raise TypeError(f"Unsupported TOML value type: {type(value).__name__}")
+
+
+def _is_array_of_tables(value: Any) -> bool:
+    return isinstance(value, list) and len(value) > 0 and all(isinstance(item, dict) for item in value)
+
+
+def _split_kinds(data: dict[str, Any]) -> tuple[list[tuple[str, Any]], list[tuple[str, dict]], list[tuple[str, list[dict]]]]:
+    """Split a table's items into (scalars, sub-tables, arrays-of-tables) preserving order."""
+    scalars: list[tuple[str, Any]] = []
+    tables: list[tuple[str, dict]] = []
+    arrays: list[tuple[str, list[dict]]] = []
+    for key, value in data.items():
+        if isinstance(value, dict):
+            tables.append((key, value))
+        elif _is_array_of_tables(value):
+            arrays.append((key, value))
+        else:
+            scalars.append((key, value))
+    return scalars, tables, arrays
+
+
+def _emit_table(lines: list[str], prefix: list[str], data: dict[str, Any]) -> None:
+    """Emit a table whose path is `prefix`. Top-level call uses prefix=[]."""
+    scalars, tables, arrays = _split_kinds(data)
+    header = ".".join(_toml_key(seg) for seg in prefix) if prefix else ""
+
+    if scalars:
+        if header:
+            lines.append(f"[{header}]")
+        for key, value in scalars:
+            lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
+        lines.append("")
+    elif header and not tables and not arrays:
+        # Empty leaf table — emit explicit header so it round-trips.
+        lines.append(f"[{header}]")
+        lines.append("")
+
+    for key, table in tables:
+        _emit_table(lines, prefix + [key], table)
+
+    for key, items in arrays:
+        item_header = ".".join(_toml_key(seg) for seg in prefix + [key])
+        for item in items:
+            lines.append(f"[[{item_header}]]")
+            _emit_array_table_body(lines, prefix + [key], item)
+
+
+def _emit_array_table_body(lines: list[str], prefix: list[str], data: dict[str, Any]) -> None:
+    """Emit the body of one array-of-tables element (header already emitted)."""
+    scalars, tables, arrays = _split_kinds(data)
+
+    for key, value in scalars:
+        lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
+    if scalars or (not tables and not arrays):
+        lines.append("")
+
+    for key, table in tables:
+        _emit_table(lines, prefix + [key], table)
+
+    for key, items in arrays:
+        item_header = ".".join(_toml_key(seg) for seg in prefix + [key])
+        for item in items:
+            lines.append(f"[[{item_header}]]")
+            _emit_array_table_body(lines, prefix + [key], item)
+
+
+def _toml_dumps(data: dict[str, Any]) -> str:
+    """Serialize a dict to TOML, preserving all keys and insertion order.
+
+    Comments are not preserved (tomllib drops them on load). Section ordering
+    follows the parsed dict's insertion order, with scalars-before-tables within
+    each table to satisfy TOML's parsing rules.
+    """
+    lines: list[str] = []
+    _emit_table(lines, [], data)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _set_remote_serial(user_toml: str | Path, companions_csv: str) -> None:
+    """Set [remote_serial] enabled/allowed_companions, replacing any existing block."""
+    path = Path(user_toml)
+    data = _load_user_toml(path)
+
+    companions = [k.strip() for k in companions_csv.split(",") if k.strip()]
+    rs = data.get("remote_serial")
+    if not isinstance(rs, dict):
+        rs = {}
+        data["remote_serial"] = rs
+    rs["enabled"] = bool(companions)
+    rs["allowed_companions"] = companions
+
+    _write_user_toml(path, data)
+
+
+def _read_remote_serial_companions(user_toml: str | Path) -> str:
+    """Return CSV of currently-configured remote_serial allowed_companions."""
+    path = Path(user_toml)
+    if not path.exists():
+        return ""
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return ""
+    rs = data.get("remote_serial")
+    if not isinstance(rs, dict):
+        return ""
+    companions = rs.get("allowed_companions", [])
+    if not isinstance(companions, list):
+        return ""
+    return ",".join(str(c) for c in companions if c)
 
 
 # ---------------------------------------------------------------------------
@@ -970,8 +1069,9 @@ def configure_mqtt_brokers(ctx: InstallerContext) -> None:
         if not prompt_yes_no("Add or manage another broker preset or custom broker?", "n"):
             break
 
-    if token_preset_brokers(ctx.config_dir):
+    if configured_presets(ctx.config_dir):
         _configure_iata_for_presets(user_toml, ctx)
+    if token_preset_brokers(ctx.config_dir):
         _configure_token_preset_overrides(ctx.config_dir)
 
     if not added_brokers and not had_existing_brokers:
@@ -1040,11 +1140,15 @@ def _configure_token_preset_overrides(config_dir: str) -> None:
         _rewrite_token_owner_overrides_toml(user_toml, broker_names, owner_pubkey, owner_email)
         print_success(f"Owner info updated for {preset_path.name}")
 
-    allowed_companions = prompt_allowed_companions()
-    if allowed_companions:
-        append_remote_serial_toml(user_toml, allowed_companions)
-        count = len([k for k in allowed_companions.split(",") if k.strip()])
-        print_success(f"Remote serial access enabled with {count} companion(s)")
+    existing_companions = _read_remote_serial_companions(user_toml)
+    new_companions = prompt_allowed_companions(existing_companions)
+    if new_companions != existing_companions:
+        _set_remote_serial(user_toml, new_companions)
+        if new_companions:
+            count = len([k for k in new_companions.split(",") if k.strip()])
+            print_success(f"Remote serial access enabled with {count} companion(s)")
+        else:
+            print_success("Remote serial access disabled")
 
 
 def _shared_metadata_default(metadata: dict[str, tuple[str, str]], idx: int) -> str:
@@ -1221,33 +1325,10 @@ def update_owner_info(config_dir: str) -> None:
     Path(user_toml).write_text(content)
 
     # Prompt for remote serial companions
-    existing_companions = ""
-    comp_match = re.search(r'allowed_companions\s*=\s*\[(.*?)\]', content)
-    if comp_match:
-        raw = comp_match.group(1)
-        existing_companions = ",".join(
-            k.strip().strip('"') for k in raw.split(",") if k.strip().strip('"')
-        )
-
+    existing_companions = _read_remote_serial_companions(user_toml)
     new_companions = prompt_allowed_companions(existing_companions)
-
     if new_companions != existing_companions:
-        companions_array = _companions_to_toml_array(new_companions)
-        new_enabled = "true" if new_companions else "false"
-
-        content = Path(user_toml).read_text()
-        if "[remote_serial]" in content:
-            content = re.sub(
-                r'^(enabled\s*=\s*).*$', f"\\1{new_enabled}",
-                content, count=1, flags=re.MULTILINE,
-            )
-            content = re.sub(
-                r'^(allowed_companions\s*=\s*).*$', f"\\1{companions_array}",
-                content, count=1, flags=re.MULTILINE,
-            )
-            Path(user_toml).write_text(content)
-        else:
-            append_remote_serial_toml(user_toml, new_companions)
+        _set_remote_serial(user_toml, new_companions)
 
     # Summary
     changes = []

--- a/installer/config.py
+++ b/installer/config.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
+import tempfile
+import tomllib
+import time
 import urllib.request
 import urllib.error
+from urllib.parse import urlparse
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
@@ -24,6 +29,37 @@ if TYPE_CHECKING:
     from . import InstallerContext
 
 IATA_API_BASE = "https://api.letsmesh.net/api/iata"
+USER_CONFIG_FILENAME = "99-user.toml"
+LEGACY_USER_CONFIG_FILENAME = "00-user.toml"
+PRESET_PREFIX = "10-"
+
+
+def user_config_path(config_dir: str | Path) -> Path:
+    """Return the canonical user override path."""
+    return Path(config_dir) / "config.d" / USER_CONFIG_FILENAME
+
+
+def legacy_user_config_path(config_dir: str | Path) -> Path:
+    """Return the legacy user override path."""
+    return Path(config_dir) / "config.d" / LEGACY_USER_CONFIG_FILENAME
+
+
+def migrate_user_config_filename(config_dir: str | Path) -> Path:
+    """Rename legacy 00-user.toml to 99-user.toml so user overrides load last."""
+    new_path = user_config_path(config_dir)
+    old_path = legacy_user_config_path(config_dir)
+
+    if old_path.exists() and new_path.exists():
+        print_error(
+            f"Both {old_path} and {new_path} exist. Remove or merge one before continuing."
+        )
+        raise SystemExit(1)
+
+    if old_path.exists():
+        old_path.rename(new_path)
+        print_success(f"Migrated user config to {new_path}")
+
+    return new_path
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +120,7 @@ def _companions_to_toml_array(csv: str) -> str:
 # ---------------------------------------------------------------------------
 
 def write_user_toml_base(dest: str, iata: str, serial_device: str, repo: str, branch: str) -> None:
-    """Write the initial 00-user.toml with general settings and serial config."""
+    """Write the initial user TOML with general settings and serial config."""
     content = f"""# MeshCore to MQTT - User Configuration
 # This file contains your local overrides to the defaults in config.toml
 
@@ -120,7 +156,7 @@ def append_letsmesh_broker_toml(
     owner: str,
     email: str,
 ) -> None:
-    """Append a LetsMesh broker block to 00-user.toml."""
+    """Append a LetsMesh broker block to a TOML file."""
     block = f"""
 [[broker]]
 name = "{toml_escape(broker_name)}"
@@ -161,7 +197,7 @@ def append_custom_broker_toml(
     owner: str = "",
     email: str = "",
 ) -> None:
-    """Append a custom broker block to 00-user.toml."""
+    """Append a custom broker block to a TOML file."""
     lines = [
         "",
         "[[broker]]",
@@ -197,7 +233,7 @@ def append_custom_broker_toml(
 
 
 def append_remote_serial_toml(dest: str, companions_csv: str) -> None:
-    """Append remote serial config to 00-user.toml."""
+    """Append remote serial config to a TOML file."""
     companions_array = _companions_to_toml_array(companions_csv)
     enabled = "true" if companions_csv else "false"
 
@@ -208,6 +244,332 @@ allowed_companions = {companions_array}
 """
     with open(dest, "a") as f:
         f.write(block)
+
+
+def append_token_owner_overrides_toml(
+    dest: str,
+    broker_names: list[str],
+    owner: str,
+    email: str,
+) -> None:
+    """Append local auth metadata overrides for token-auth preset brokers."""
+    if not owner and not email:
+        return
+
+    lines: list[str] = []
+    for broker_name in broker_names:
+        lines.extend([
+            "",
+            "[[broker]]",
+            f'name = "{toml_escape(broker_name)}"',
+            "",
+            "[broker.auth]",
+        ])
+        if owner:
+            lines.append(f'owner = "{toml_escape(owner)}"')
+        if email:
+            lines.append(f'email = "{toml_escape(email)}"')
+
+    lines.append("")
+    with open(dest, "a") as f:
+        f.write("\n".join(lines))
+
+
+def _rewrite_token_owner_overrides_toml(
+    dest: str,
+    broker_names: list[str],
+    owner: str,
+    email: str,
+) -> None:
+    """Replace local auth metadata overrides for the given brokers."""
+    path = Path(dest)
+    data: dict[str, Any] = {}
+    if path.exists():
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+
+    brokers = data.get("broker", [])
+    if not isinstance(brokers, list):
+        brokers = []
+
+    by_name: dict[str, dict[str, Any]] = {}
+    ordered: list[dict[str, Any]] = []
+    for broker in brokers:
+        if not isinstance(broker, dict):
+            continue
+        name = broker.get("name")
+        if isinstance(name, str):
+            by_name[name] = broker
+        ordered.append(broker)
+
+    for broker_name in broker_names:
+        broker = by_name.get(broker_name)
+        if broker is None:
+            broker = {"name": broker_name}
+            by_name[broker_name] = broker
+            ordered.append(broker)
+        auth = broker.get("auth")
+        if not isinstance(auth, dict):
+            auth = {}
+            broker["auth"] = auth
+        if owner:
+            auth["owner"] = owner
+        else:
+            auth.pop("owner", None)
+        if email:
+            auth["email"] = email
+        else:
+            auth.pop("email", None)
+
+    content = _toml_dumps_user_config(data, ordered)
+    path.write_text(content)
+
+
+def _remove_broker_overrides_toml(dest: str | Path, broker_names: list[str]) -> None:
+    """Remove local broker override blocks for the given broker names."""
+    path = Path(dest)
+    if not path.exists():
+        return
+
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+
+    brokers = data.get("broker", [])
+    if not isinstance(brokers, list):
+        return
+
+    remove_names = set(broker_names)
+    kept = [
+        broker for broker in brokers
+        if not isinstance(broker, dict) or broker.get("name") not in remove_names
+    ]
+    content = _toml_dumps_user_config(data, kept)
+    path.write_text(content)
+
+
+def _toml_dumps_user_config(data: dict[str, Any], brokers: list[dict[str, Any]]) -> str:
+    """Serialize installer-managed user config TOML."""
+    lines = [
+        "# MeshCore to MQTT - User Configuration",
+        "# This file contains your local overrides to the defaults in config.toml",
+        "",
+    ]
+
+    for section in ("general", "serial", "update", "remote_serial"):
+        value = data.get(section)
+        if isinstance(value, dict):
+            lines.append(f"[{section}]")
+            for key, item in value.items():
+                lines.append(f"{key} = {_toml_value(item)}")
+            lines.append("")
+
+    for broker in brokers:
+        name = broker.get("name")
+        if not isinstance(name, str):
+            continue
+        lines.append("[[broker]]")
+        lines.append(f'name = "{toml_escape(name)}"')
+        for key, item in broker.items():
+            if key in ("name", "auth", "tls", "topics") or isinstance(item, dict):
+                continue
+            lines.append(f"{key} = {_toml_value(item)}")
+        for nested in ("tls", "auth", "topics"):
+            nested_data = broker.get(nested)
+            if isinstance(nested_data, dict):
+                lines.append("")
+                lines.append(f"[broker.{nested}]")
+                for key, item in nested_data.items():
+                    lines.append(f"{key} = {_toml_value(item)}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    return f'"{toml_escape(str(value))}"'
+
+
+# ---------------------------------------------------------------------------
+# Preset helpers
+# ---------------------------------------------------------------------------
+
+def _safe_preset_basename(name: str) -> str:
+    """Validate and return a safe TOML preset basename."""
+    basename = Path(name).name
+    if basename != name or not basename or basename in (".", ".."):
+        raise ValueError("Preset filename must be a simple basename")
+    if "/" in basename or "\\" in basename:
+        raise ValueError("Preset filename must not contain path separators")
+    if not basename.endswith(".toml"):
+        raise ValueError("Preset filename must end with .toml")
+    if basename.startswith("."):
+        raise ValueError("Preset filename must not be hidden")
+    return basename
+
+
+def preset_dest_path(config_dir: str | Path, original_filename: str) -> Path:
+    """Return the active config.d path for a preset filename."""
+    basename = _safe_preset_basename(original_filename)
+    if basename.startswith(PRESET_PREFIX):
+        dest_name = basename
+    else:
+        dest_name = f"{PRESET_PREFIX}{basename}"
+    return Path(config_dir) / "config.d" / dest_name
+
+
+def validate_preset_toml(path: str | Path) -> dict[str, Any]:
+    """Load and validate a broker preset TOML file."""
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+
+    brokers = data.get("broker")
+    if not isinstance(brokers, list) or not brokers:
+        raise ValueError("Preset must contain at least one [[broker]] block")
+
+    for broker in brokers:
+        if not isinstance(broker, dict) or not broker.get("name"):
+            raise ValueError("Every preset broker must have a name")
+
+    return data
+
+
+def list_bundled_presets(repo_dir: str | Path) -> list[Path]:
+    """List bundled preset TOML files from the checked-out or downloaded repo."""
+    preset_dir = Path(repo_dir) / "presets"
+    if not preset_dir.is_dir():
+        return []
+    return sorted(p for p in preset_dir.glob("*.toml") if p.is_file())
+
+
+def copy_preset_to_config(source: str | Path, config_dir: str | Path) -> Path:
+    """Validate and copy a preset into config.d with the preset prefix."""
+    source_path = Path(source)
+    dest = preset_dest_path(config_dir, source_path.name)
+    validate_preset_toml(source_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, dest)
+    return dest
+
+
+def _filename_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    return Path(parsed.path).name
+
+
+def import_preset_to_config(source: str, config_dir: str | Path) -> Path:
+    """Import a preset from a local path or URL into config.d."""
+    if re.match(r"^https?://", source):
+        filename = _safe_preset_basename(_filename_from_url(source))
+        dest = preset_dest_path(config_dir, filename)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            req = urllib.request.Request(
+                source,
+                headers={"User-Agent": "meshcoretomqtt-installer"},
+            )
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                tmp_path.write_bytes(resp.read())
+            validate_preset_toml(tmp_path)
+            shutil.copy2(tmp_path, dest)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+        return dest
+
+    source_path = Path(source).expanduser()
+    _safe_preset_basename(source_path.name)
+    return copy_preset_to_config(source_path, config_dir)
+
+
+def token_broker_names_from_preset(path: str | Path) -> list[tuple[str, str]]:
+    """Return (preset filename, broker name) entries for token-auth brokers."""
+    data = validate_preset_toml(path)
+    names: list[tuple[str, str]] = []
+    for broker in data.get("broker", []):
+        auth = broker.get("auth", {})
+        if isinstance(auth, dict) and auth.get("method") == "token":
+            names.append((Path(path).name, str(broker["name"])))
+    return names
+
+
+def token_preset_brokers(config_dir: str | Path) -> dict[Path, list[str]]:
+    """Return token-auth broker names grouped by active preset file."""
+    config_d = Path(config_dir) / "config.d"
+    result: dict[Path, list[str]] = {}
+    if not config_d.is_dir():
+        return result
+
+    for preset in sorted(config_d.glob(f"{PRESET_PREFIX}*.toml")):
+        try:
+            broker_names = [name for _preset, name in token_broker_names_from_preset(preset)]
+        except (OSError, ValueError, tomllib.TOMLDecodeError):
+            continue
+        if broker_names:
+            result[preset] = broker_names
+    return result
+
+
+def configured_presets(config_dir: str | Path) -> dict[Path, list[str]]:
+    """Return active preset files and their broker names."""
+    config_d = Path(config_dir) / "config.d"
+    result: dict[Path, list[str]] = {}
+    if not config_d.is_dir():
+        return result
+
+    for preset in sorted(config_d.glob(f"{PRESET_PREFIX}*.toml")):
+        try:
+            data = validate_preset_toml(preset)
+        except (OSError, ValueError, tomllib.TOMLDecodeError):
+            result[preset] = []
+            continue
+        brokers = data.get("broker", [])
+        names = [
+            str(broker["name"]) for broker in brokers
+            if isinstance(broker, dict) and broker.get("name")
+        ]
+        result[preset] = names
+    return result
+
+
+def _broker_auth_metadata(config_dir: str | Path, broker_name: str) -> tuple[str, str]:
+    """Return effective owner/email for a broker from config.d load order."""
+    owner = ""
+    email = ""
+    config_d = Path(config_dir) / "config.d"
+    if not config_d.is_dir():
+        return owner, email
+
+    for path in sorted(config_d.glob("*.toml")):
+        try:
+            data = validate_preset_toml(path) if path.name.startswith(PRESET_PREFIX) else _load_toml_file(path)
+        except (OSError, ValueError, tomllib.TOMLDecodeError):
+            continue
+        brokers = data.get("broker", [])
+        if not isinstance(brokers, list):
+            continue
+        for broker in brokers:
+            if not isinstance(broker, dict) or broker.get("name") != broker_name:
+                continue
+            auth = broker.get("auth", {})
+            if not isinstance(auth, dict):
+                continue
+            if "owner" in auth:
+                owner = str(auth.get("owner") or "")
+            if "email" in auth:
+                email = str(auth.get("email") or "")
+    return owner, email
+
+
+def _load_toml_file(path: str | Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
 
 
 # ---------------------------------------------------------------------------
@@ -235,14 +597,30 @@ def search_iata_api(query: str, script_version: str = "unknown") -> list[tuple[s
         return []
 
 
+def _lookup_iata_code_with_retry(
+    code: str,
+    script_version: str = "unknown",
+    attempts: int = 3,
+) -> tuple[str | None, bool]:
+    """Look up an IATA code. Returns (airport name, validation_unavailable)."""
+    url = _iata_api_url(f"code={urllib.request.quote(code)}", script_version)
+    for attempt in range(1, attempts + 1):
+        try:
+            data = json.loads(_iata_request(url))
+            if not isinstance(data, dict):
+                return None, False
+            return data.get("name"), False
+        except (urllib.error.URLError, json.JSONDecodeError, KeyError, OSError):
+            if attempt == attempts:
+                return None, True
+            time.sleep(1)
+    return None, True
+
+
 def lookup_iata_code(code: str, script_version: str = "unknown") -> str | None:
     """Look up a specific IATA code. Returns airport name or None."""
-    url = _iata_api_url(f"code={urllib.request.quote(code)}", script_version)
-    try:
-        data = json.loads(_iata_request(url))
-        return data.get("name")
-    except (urllib.error.URLError, json.JSONDecodeError, KeyError, OSError):
-        return None
+    name, _validation_unavailable = _lookup_iata_code_with_retry(code, script_version)
+    return name
 
 
 # ---------------------------------------------------------------------------
@@ -292,7 +670,7 @@ def prompt_iata_letsmesh(existing: str = "", script_version: str = "unknown") ->
         # If exactly 3 uppercase letters, try direct lookup
         if re.fullmatch(r"[A-Z]{3}", upper_query):
             print_info(f"Looking up {upper_query}...")
-            name = lookup_iata_code(upper_query, script_version)
+            name, validation_unavailable = _lookup_iata_code_with_retry(upper_query, script_version)
             if name:
                 print()
                 print_success(f"Found: {upper_query} - {name}")
@@ -303,8 +681,20 @@ def prompt_iata_letsmesh(existing: str = "", script_version: str = "unknown") ->
                     return upper_query
                 print()
                 continue
+            if validation_unavailable:
+                print_warning(f"Could not validate IATA code '{upper_query}' after retrying")
+                if prompt_yes_no(f"Use '{upper_query}' without validation?", "y"):
+                    print()
+                    print_success(f"Selected: {upper_query}")
+                    return upper_query
+                print()
+                continue
             else:
-                print_error(f"IATA code '{upper_query}' not found in database")
+                print_warning(f"IATA code '{upper_query}' was not found in the LetsMesh database")
+                if prompt_yes_no(f"Use '{upper_query}' anyway?", "y"):
+                    print()
+                    print_success(f"Selected: {upper_query}")
+                    return upper_query
                 print()
                 continue
 
@@ -448,7 +838,7 @@ def prompt_allowed_companions(existing: str = "") -> str:
 
 def configure_custom_broker(broker_num: int, config_dir: str) -> None:
     """Configure a single custom MQTT broker interactively."""
-    user_toml = f"{config_dir}/config.d/00-user.toml"
+    user_toml = str(migrate_user_config_filename(config_dir))
 
     print()
     print_header(f"Configuring MQTT Broker {broker_num}")
@@ -515,79 +905,77 @@ def configure_custom_broker(broker_num: int, config_dir: str) -> None:
 
 def configure_mqtt_brokers(ctx: InstallerContext) -> None:
     """Interactive MQTT broker configuration flow."""
-    user_toml = f"{ctx.config_dir}/config.d/00-user.toml"
+    user_toml_path = migrate_user_config_filename(ctx.config_dir)
+    user_toml = str(user_toml_path)
 
-    # Ensure 00-user.toml exists with base settings
+    # Ensure 99-user.toml exists with base settings
     if not Path(user_toml).exists():
         from .system import select_serial_device
         serial_device = select_serial_device()
         write_user_toml_base(user_toml, "XXX", serial_device, ctx.repo, ctx.branch)
 
-    print()
-    print_header("MQTT Broker Configuration")
-    print()
-    print_info("Enable the LetsMesh.net Packet Analyzer MQTT servers?")
-    print("  - Real-time packet analysis and visualization")
-    print("  - Network health monitoring")
-    print("  - Includes US and EU regional brokers for redundancy")
-    print()
+    added_brokers = False
+    had_existing_brokers = _config_dir_has_broker(ctx.config_dir)
 
-    if prompt_yes_no("Enable LetsMesh Packet Analyzer MQTT servers?", "y"):
-        # LetsMesh IATA selection via API (no jq needed!)
-        existing_iata = _read_existing_iata(user_toml)
-        if not existing_iata or existing_iata == "XXX":
-            iata = prompt_iata_letsmesh("", ctx.script_version)
-            _update_iata_in_file(user_toml, iata)
-            print_success(f"IATA code set to: {iata}")
-
-        # Prompt for owner info
+    while True:
         print()
-        print_info("LetsMesh Packet Analyzer supports optional owner identification")
-        print_info("This links your observer to your MeshCore public key and email")
-        owner_pubkey = prompt_owner_pubkey()
-        owner_email = prompt_owner_email()
-        allowed_companions = prompt_allowed_companions()
+        print_header("MQTT Broker Configuration")
+        print()
+        _print_configured_presets(ctx.config_dir)
+        print_info("Choose how to configure MQTT brokers:")
+        print("  1) Select bundled broker presets")
+        print("  2) Import a preset from a URL or local path")
+        print("  3) Configure a custom MQTT broker")
+        print("  4) Manage existing presets")
+        print("  5) Finish without adding or changing brokers")
+        print()
 
-        # Configure US and EU brokers
-        append_letsmesh_broker_toml(
-            user_toml, "letsmesh-us",
-            "mqtt-us-v1.letsmesh.net", "mqtt-us-v1.letsmesh.net",
-            owner_pubkey, owner_email,
-        )
-        append_letsmesh_broker_toml(
-            user_toml, "letsmesh-eu",
-            "mqtt-eu-v1.letsmesh.net", "mqtt-eu-v1.letsmesh.net",
-            owner_pubkey, owner_email,
-        )
+        choice = prompt_input("Choose broker setup option [1-5]", "1")
 
-        if allowed_companions:
-            append_remote_serial_toml(user_toml, allowed_companions)
-            count = len([k for k in allowed_companions.split(",") if k.strip()])
-            print_success(f"Remote serial access enabled with {count} companion(s)")
-
-        # Build success message
-        owner_info = ""
-        if owner_pubkey and owner_email:
-            owner_info = f" with owner: {owner_pubkey} ({owner_email})"
-        elif owner_pubkey:
-            owner_info = f" with owner: {owner_pubkey}"
-        elif owner_email:
-            owner_info = f" with email: {owner_email}"
-        print_success(f"LetsMesh Packet Analyzer MQTT servers enabled{owner_info}")
-
-        if prompt_yes_no("Would you like to configure additional MQTT brokers?", "n"):
-            _configure_additional_brokers(ctx)
-    else:
-        # User declined LetsMesh — disable both default brokers
-        append_disabled_broker_toml(user_toml, "letsmesh-us")
-        append_disabled_broker_toml(user_toml, "letsmesh-eu")
-        if prompt_yes_no("Would you like to configure a custom MQTT broker?", "y"):
+        if choice == "1":
+            selected = _select_bundled_presets(ctx)
+            if selected:
+                for preset in selected:
+                    try:
+                        copied = copy_preset_to_config(preset, ctx.config_dir)
+                        print_success(f"Preset installed: {copied.name}")
+                        added_brokers = True
+                    except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
+                        print_error(f"Failed to install preset {preset.name}: {exc}")
+            else:
+                print_warning("No bundled presets selected")
+        elif choice == "2":
+            source = prompt_input("Preset URL or local path")
+            if not source:
+                print_warning("No preset source provided")
+            else:
+                try:
+                    copied = import_preset_to_config(source, ctx.config_dir)
+                    print_success(f"Preset installed: {copied.name}")
+                    added_brokers = True
+                except (OSError, ValueError, tomllib.TOMLDecodeError, urllib.error.URLError) as exc:
+                    print_error(f"Failed to import preset: {exc}")
+        elif choice == "3":
             _configure_iata_simple(user_toml)
-            configure_custom_broker(1, ctx.config_dir)
-            if prompt_yes_no("Would you like to configure additional MQTT brokers?", "n"):
-                _configure_additional_brokers(ctx)
+            configure_custom_broker(_next_custom_broker_number(ctx.config_dir), ctx.config_dir)
+            added_brokers = True
+        elif choice == "4":
+            _manage_existing_presets(ctx.config_dir)
+        elif choice == "5":
+            break
         else:
-            print_warning(f"No MQTT brokers configured - you'll need to edit {user_toml} manually")
+            print_error("Invalid selection")
+            continue
+
+        if not prompt_yes_no("Add or manage another broker preset or custom broker?", "n"):
+            break
+
+    if token_preset_brokers(ctx.config_dir):
+        _configure_iata_for_presets(user_toml, ctx)
+        _configure_token_preset_overrides(ctx.config_dir)
+
+    if not added_brokers and not had_existing_brokers:
+        print_warning(f"No MQTT brokers configured - you'll need to edit {user_toml} manually")
 
     # Fix ownership after writing config
     if platform.system() != "Darwin" and ctx.svc_user:
@@ -597,7 +985,7 @@ def configure_mqtt_brokers(ctx: InstallerContext) -> None:
 
 
 def _configure_iata_simple(user_toml: str) -> None:
-    """Prompt for simple IATA and update 00-user.toml."""
+    """Prompt for simple IATA and update the user TOML."""
     existing_iata = _read_existing_iata(user_toml)
     if not existing_iata or existing_iata == "XXX":
         iata = prompt_iata_simple()
@@ -605,24 +993,171 @@ def _configure_iata_simple(user_toml: str) -> None:
         print_success(f"IATA code set to: {iata}")
 
 
-def _configure_additional_brokers(ctx: InstallerContext) -> None:
-    """Configure additional custom brokers."""
-    user_toml = f"{ctx.config_dir}/config.d/00-user.toml"
-    # Count existing broker blocks
+def _configure_iata_for_presets(user_toml: str, ctx: InstallerContext) -> None:
+    """Prompt for IATA for preset brokers if the user config still needs it."""
+    existing_iata = _read_existing_iata(user_toml)
+    if not existing_iata or existing_iata == "XXX":
+        iata = prompt_iata_letsmesh("", ctx.script_version)
+        _update_iata_in_file(user_toml, iata)
+        print_success(f"IATA code set to: {iata}")
+
+
+def _configure_token_preset_overrides(config_dir: str) -> None:
+    """Configure owner/email overrides separately for each token-auth preset."""
+    user_toml = str(user_config_path(config_dir))
+    presets = token_preset_brokers(config_dir)
+    if not presets:
+        return
+
+    print()
+    print_info("Token-authenticated broker presets support optional owner identification")
+    print_info("This links your observer to your MeshCore public key and email")
+
+    for preset_path, broker_names in presets.items():
+        print()
+        print_header(f"Owner Info: {preset_path.name}")
+        print_info("Token-authenticated brokers in this preset:")
+
+        metadata = {
+            broker_name: _broker_auth_metadata(config_dir, broker_name)
+            for broker_name in broker_names
+        }
+        has_owner_info = any(owner or email for owner, email in metadata.values())
+
+        for broker_name in broker_names:
+            owner, email = metadata[broker_name]
+            print(f"  - {broker_name}")
+            print(f"    owner: {owner or '(not set)'}")
+            print(f"    email: {email or '(not set)'}")
+
+        if has_owner_info and not prompt_yes_no(f"Change owner info for {preset_path.name}?", "n"):
+            continue
+
+        owner_default = _shared_metadata_default(metadata, 0)
+        email_default = _shared_metadata_default(metadata, 1)
+        owner_pubkey = prompt_owner_pubkey(owner_default)
+        owner_email = prompt_owner_email(email_default)
+        _rewrite_token_owner_overrides_toml(user_toml, broker_names, owner_pubkey, owner_email)
+        print_success(f"Owner info updated for {preset_path.name}")
+
+    allowed_companions = prompt_allowed_companions()
+    if allowed_companions:
+        append_remote_serial_toml(user_toml, allowed_companions)
+        count = len([k for k in allowed_companions.split(",") if k.strip()])
+        print_success(f"Remote serial access enabled with {count} companion(s)")
+
+
+def _shared_metadata_default(metadata: dict[str, tuple[str, str]], idx: int) -> str:
+    """Return the shared existing owner/email value if all brokers agree."""
+    values = {pair[idx] for pair in metadata.values() if pair[idx]}
+    return values.pop() if len(values) == 1 else ""
+
+
+def _print_configured_presets(config_dir: str) -> None:
+    """Print a summary of active preset files."""
+    presets = configured_presets(config_dir)
+    if not presets:
+        print_info("Configured broker presets: none")
+        print()
+        return
+
+    print_info("Configured broker presets:")
+    for preset, broker_names in presets.items():
+        brokers = ", ".join(broker_names) if broker_names else "no valid broker blocks"
+        print(f"  - {preset.name}: {brokers}")
+    print()
+
+
+def _manage_existing_presets(config_dir: str) -> None:
+    """Delete configured preset files and matching user overrides."""
+    presets = configured_presets(config_dir)
+    if not presets:
+        print_warning("No configured presets found")
+        return
+
+    print()
+    print_info("Configured broker presets:")
+    preset_items = list(presets.items())
+    for idx, (preset, broker_names) in enumerate(preset_items, 1):
+        brokers = ", ".join(broker_names) if broker_names else "no valid broker blocks"
+        print(f"  {idx}) {preset.name}: {brokers}")
+    print()
+
+    raw = prompt_input(f"Select presets to delete (enter without a selection to return) [1-{len(preset_items)}], comma-separated")
+    selected = _parse_number_selection(raw, len(preset_items))
+    if not selected:
+        print_warning("No presets selected")
+        return
+
+    user_toml = user_config_path(config_dir)
+    for idx in selected:
+        preset, broker_names = preset_items[idx - 1]
+        if not prompt_yes_no(f"Delete {preset.name}?", "n"):
+            continue
+        preset.unlink(missing_ok=True)
+        _remove_broker_overrides_toml(user_toml, broker_names)
+        print_success(f"Deleted {preset.name} and removed matching user overrides")
+
+
+def _parse_number_selection(raw: str, max_value: int) -> list[int]:
+    """Parse comma-separated numeric selections."""
+    selected: list[int] = []
+    seen: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if not part.isdigit():
+            print_warning(f"Ignoring invalid selection: {part}")
+            continue
+        idx = int(part)
+        if idx < 1 or idx > max_value:
+            print_warning(f"Ignoring out-of-range selection: {part}")
+            continue
+        if idx not in seen:
+            selected.append(idx)
+            seen.add(idx)
+    return selected
+
+
+def _select_bundled_presets(ctx: InstallerContext) -> list[Path]:
+    """Prompt for one or more bundled presets."""
+    presets = list_bundled_presets(ctx.repo_dir)
+    if not presets:
+        print_warning("No bundled presets found")
+        return []
+
+    default_idx = 1
+    for idx, preset in enumerate(presets, 1):
+        if preset.name == "letsmesh.toml":
+            default_idx = idx
+            break
+
+    print()
+    print_info("Available broker presets:")
+    for idx, preset in enumerate(presets, 1):
+        print(f"  {idx}) {preset.name}")
+    print()
+
+    raw = prompt_input(f"Select presets [1-{len(presets)}], comma-separated", str(default_idx))
+    return [presets[idx - 1] for idx in _parse_number_selection(raw, len(presets))]
+
+
+def _next_custom_broker_number(config_dir: str) -> int:
+    """Choose the next custom broker number based on active config snippets."""
+    config_d = Path(config_dir) / "config.d"
     existing_count = 0
-    if Path(user_toml).exists():
-        content = Path(user_toml).read_text()
-        existing_count = content.count("[[broker]]")
+    for path in config_d.glob("*.toml"):
+        existing_count += path.read_text().count("[[broker]]")
+    return existing_count + 1
 
-    num_str = prompt_input("How many additional brokers?", "1")
-    try:
-        num_additional = int(num_str)
-    except ValueError:
-        num_additional = 1
 
-    for i in range(num_additional):
-        broker_num = existing_count + i + 1
-        configure_custom_broker(broker_num, ctx.config_dir)
+def _config_dir_has_broker(config_dir: str) -> bool:
+    """Return whether any active config drop-in already contains broker blocks."""
+    config_d = Path(config_dir) / "config.d"
+    if not config_d.is_dir():
+        return False
+    return any("[[broker]]" in path.read_text() for path in config_d.glob("*.toml"))
 
 
 # ---------------------------------------------------------------------------
@@ -631,7 +1166,7 @@ def _configure_additional_brokers(ctx: InstallerContext) -> None:
 
 def update_owner_info(config_dir: str) -> None:
     """Update owner public key and email for existing token-auth brokers."""
-    user_toml = f"{config_dir}/config.d/00-user.toml"
+    user_toml = str(migrate_user_config_filename(config_dir))
 
     if not Path(user_toml).exists():
         print_error("No configuration file found")
@@ -641,9 +1176,15 @@ def update_owner_info(config_dir: str) -> None:
     print_header("Update Owner Information")
 
     content = Path(user_toml).read_text()
-    if 'method = "token"' not in content:
+    has_token_presets = bool(token_preset_brokers(config_dir))
+    if 'method = "token"' not in content and not has_token_presets:
         print_warning("No brokers configured with auth token authentication")
         return
+
+    if has_token_presets:
+        _configure_token_preset_overrides(config_dir)
+        if 'method = "token"' not in content:
+            return
 
     print_info("This will update owner and email for all token-auth brokers")
     print()
@@ -732,7 +1273,7 @@ def update_owner_info(config_dir: str) -> None:
 # ---------------------------------------------------------------------------
 
 def _read_existing_iata(user_toml: str) -> str:
-    """Read the existing IATA code from 00-user.toml."""
+    """Read the existing IATA code from a user TOML."""
     if not Path(user_toml).exists():
         return ""
     content = Path(user_toml).read_text()
@@ -741,7 +1282,7 @@ def _read_existing_iata(user_toml: str) -> str:
 
 
 def _update_iata_in_file(user_toml: str, iata: str) -> None:
-    """Update the iata value in 00-user.toml."""
+    """Update the iata value in a user TOML."""
     content = Path(user_toml).read_text()
     content = re.sub(r'^(iata\s*=\s*).*$', f'\\1"{iata}"', content, flags=re.MULTILINE)
     Path(user_toml).write_text(content)

--- a/installer/install_cmd.py
+++ b/installer/install_cmd.py
@@ -11,15 +11,21 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from . import extract_version_from_file
-from .config import configure_mqtt_brokers, update_owner_info, _read_existing_iata, prompt_iata_letsmesh, prompt_iata_simple, _update_iata_in_file
-from .migrate_cmd import detect_old_installation, run_migrate
+from .config import (
+    configure_mqtt_brokers,
+    _read_existing_iata,
+    prompt_iata_letsmesh,
+    prompt_iata_simple,
+    _update_iata_in_file,
+    migrate_user_config_filename,
+    user_config_path,
+)
+from .migrate_cmd import run_migrate
 from .system import (
     create_system_user,
     create_venv,
     create_version_info,
-    detect_system_type,
     detect_system_type_native,
-    docker_cmd,
     download_file,
     download_repo_archive,
     install_docker_service,
@@ -90,7 +96,7 @@ def _do_install(ctx: InstallerContext, tmp_dir: str) -> None:
 
     # Check if functional installation exists
     updating_existing = False
-    user_toml = Path(ctx.config_dir) / "config.d" / "00-user.toml"
+    user_toml = migrate_user_config_filename(ctx.config_dir)
     has_existing = (
         Path(ctx.install_dir, "mctomqtt.py").exists()
         and user_toml.exists()
@@ -298,7 +304,7 @@ def _print_install_summary(ctx: InstallerContext, migration_done: bool) -> None:
     print(f"Configuration directory: {ctx.config_dir}")
     print()
     print(f"Base config: {ctx.config_dir}/config.toml")
-    print(f"User config: {ctx.config_dir}/config.d/00-user.toml")
+    print(f"User config: {user_config_path(ctx.config_dir)}")
     print()
 
     docker_installed = getattr(ctx, "_docker_installed", False)
@@ -357,11 +363,11 @@ def _check_python_version() -> None:
 
 
 def _handle_config_url(ctx: InstallerContext, user_toml: Path) -> None:
-    """Handle --config URL: download and set up 00-user.toml from a URL."""
+    """Handle --config URL: download and set up 99-user.toml from a URL."""
     print_info(f"Downloading configuration from: {ctx.config_url}")
 
     try:
-        download_file(ctx.config_url, str(user_toml), "00-user.toml")
+        download_file(ctx.config_url, str(user_toml), "99-user.toml")
     except subprocess.CalledProcessError:
         print_error("Failed to download configuration from URL")
         if prompt_yes_no("Continue with interactive configuration?", "y"):
@@ -406,9 +412,8 @@ def _handle_config_url(ctx: InstallerContext, user_toml: Path) -> None:
 
         if "[[broker]]" in content:
             print_success("MQTT brokers already configured in downloaded config")
-            if prompt_yes_no("Would you like to configure additional MQTT brokers?", "n"):
-                from .config import _configure_additional_brokers
-                _configure_additional_brokers(ctx)
+            if prompt_yes_no("Would you like to add broker presets or custom brokers?", "n"):
+                configure_mqtt_brokers(ctx)
         else:
             configure_mqtt_brokers(ctx)
     else:

--- a/installer/migrate_cmd.py
+++ b/installer/migrate_cmd.py
@@ -4,17 +4,13 @@ from __future__ import annotations
 
 import os
 import platform
-import re
-import shutil
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .system import download_repo_archive, run_cmd
 from .ui import (
-    print_error,
     print_header,
     print_info,
     print_success,
@@ -289,7 +285,7 @@ def run_migrate(ctx: InstallerContext) -> bool:
     # Create config directory
     os.makedirs(f"{ctx.config_dir}/config.d", exist_ok=True)
 
-    migrated_toml_path = f"{ctx.config_dir}/config.d/00-user.toml"
+    migrated_toml_path = f"{ctx.config_dir}/config.d/99-user.toml"
 
     if not merged:
         print_warning("No user configuration found to migrate")

--- a/installer/system.py
+++ b/installer/system.py
@@ -421,9 +421,8 @@ def set_permissions(install_dir: str, config_dir: str, svc_user: str) -> None:
     if config_toml.exists():
         os.chmod(str(config_toml), 0o644)
 
-    user_toml = Path(config_dir) / "config.d" / "00-user.toml"
-    if user_toml.exists():
-        os.chmod(str(user_toml), 0o644)
+    for override in config_d.glob("*.toml") if config_d.exists() else []:
+        os.chmod(str(override), 0o644)
 
     print_success(f"Permissions set on {config_dir} (root:{svc_user}, 755/644)")
 
@@ -853,9 +852,11 @@ def install_docker_service(ctx: InstallerContext) -> bool:
     if image is None:
         return False
 
-    # Get serial device from 00-user.toml
+    # Get serial device from the user override file
     serial_device = "/dev/ttyACM0"
-    user_toml = Path(ctx.config_dir) / "config.d" / "00-user.toml"
+    user_toml = Path(ctx.config_dir) / "config.d" / "99-user.toml"
+    if not user_toml.exists():
+        user_toml = Path(ctx.config_dir) / "config.d" / "00-user.toml"
     if user_toml.exists():
         import re
         match = re.search(r'^\s*ports\s*=\s*\["([^"]+)"', user_toml.read_text(), re.MULTILINE)
@@ -865,10 +866,8 @@ def install_docker_service(ctx: InstallerContext) -> bool:
     # Build docker run command
     parts = [
         "docker", "run", "-d", "--name", "mctomqtt", "--restart", "unless-stopped",
-        "-v", f"{ctx.config_dir}/config.toml:/etc/mctomqtt/config.toml:ro",
+        "-v", f"{ctx.config_dir}:/etc/mctomqtt:ro",
     ]
-    if user_toml.exists():
-        parts.extend(["-v", f"{ctx.config_dir}/config.d/00-user.toml:/etc/mctomqtt/config.d/00-user.toml:ro"])
     if Path(serial_device).exists():
         parts.append(f"--device={serial_device}")
     else:

--- a/installer/update_cmd.py
+++ b/installer/update_cmd.py
@@ -6,13 +6,18 @@ import os
 import platform
 import re
 import shutil
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from . import extract_version_from_file
-from .config import configure_mqtt_brokers, update_owner_info
+from .config import (
+    configure_mqtt_brokers,
+    update_owner_info,
+    migrate_user_config_filename,
+    token_preset_brokers,
+    user_config_path,
+)
 from .system import (
     LOCAL_IMAGE,
     check_service_health,
@@ -22,9 +27,7 @@ from .system import (
     create_venv,
     detect_service_user,
     detect_system_type,
-    docker_cmd,
     download_repo_archive,
-    install_launchd_service,
     install_systemd_service,
     pull_or_build_docker_image,
     run_cmd,
@@ -35,7 +38,6 @@ from .ui import (
     print_header,
     print_info,
     print_success,
-    print_warning,
     prompt_yes_no,
 )
 
@@ -135,7 +137,7 @@ def _do_update(ctx: InstallerContext, tmp_dir: str) -> None:
     os.chmod(f"{ctx.install_dir}/mctomqtt.py", 0o755)
     os.chmod(f"{ctx.install_dir}/uninstall.sh", 0o755)
 
-    # Update base config (overwrite config.toml, preserve 00-user.toml)
+    # Update base config (overwrite config.toml, preserve user overrides)
     shutil.copy2(os.path.join(tmp_dir, "config.toml.example"), f"{ctx.config_dir}/config.toml")
     print_success(f"Base config updated at {ctx.config_dir}/config.toml")
     print_success(f"Files updated in {ctx.install_dir}")
@@ -153,7 +155,7 @@ def _do_update(ctx: InstallerContext, tmp_dir: str) -> None:
     # ---------------------------------------------------------------------------
     print_header("Configuration")
 
-    user_toml = Path(ctx.config_dir) / "config.d" / "00-user.toml"
+    user_toml = migrate_user_config_filename(ctx.config_dir)
     if user_toml.exists():
         if ctx.update_mode:
             print_info("Keeping existing configuration")
@@ -161,14 +163,14 @@ def _do_update(ctx: InstallerContext, tmp_dir: str) -> None:
             import datetime
             timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
             shutil.copy2(str(user_toml), f"{user_toml}.backup-{timestamp}")
-            user_toml.unlink(missing_ok=True)
+            print_info(f"Backed up existing configuration to {user_toml}.backup-{timestamp}")
             configure_mqtt_brokers(ctx)
         else:
             print_info("Keeping existing configuration")
 
             # Offer owner info update for token-auth brokers
             content = user_toml.read_text()
-            if 'method = "token"' in content:
+            if 'method = "token"' in content or token_preset_brokers(ctx.config_dir):
                 print()
                 print_info("Token-authenticated brokers detected")
 
@@ -232,10 +234,8 @@ def _do_update(ctx: InstallerContext, tmp_dir: str) -> None:
 
                     parts: list[str] = [
                         "docker", "run", "-d", "--name", "mctomqtt", "--restart", "unless-stopped",
-                        "-v", f"{ctx.config_dir}/config.toml:/etc/mctomqtt/config.toml:ro",
+                        "-v", f"{ctx.config_dir}:/etc/mctomqtt:ro",
                     ]
-                    if user_toml.exists():
-                        parts.extend(["-v", f"{ctx.config_dir}/config.d/00-user.toml:/etc/mctomqtt/config.d/00-user.toml:ro"])
                     if Path(serial_device).exists():
                         parts.append(f"--device={serial_device}")
                     parts.append(image)
@@ -278,7 +278,7 @@ def _print_update_summary(ctx: InstallerContext, system_type: str) -> None:
     print(f"Configuration directory: {ctx.config_dir}")
     print()
     print(f"Base config: {ctx.config_dir}/config.toml")
-    print(f"User config: {ctx.config_dir}/config.d/00-user.toml")
+    print(f"User config: {user_config_path(ctx.config_dir)}")
     print()
 
     if system_type == "docker":

--- a/mctomqtt.py
+++ b/mctomqtt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-__version__ = "1.2.0.0-preview"
+__version__ = "1.3.0.0-preview"
 
 import argparse
 import logging

--- a/presets/letsmesh.toml
+++ b/presets/letsmesh.toml
@@ -1,0 +1,37 @@
+# LetsMesh.net Packet Analyzer broker preset
+
+[[broker]]
+name = "letsmesh-us"
+enabled = true
+server = "mqtt-us-v1.letsmesh.net"
+port = 443
+transport = "websockets"
+keepalive = 60
+qos = 0
+retain = true
+
+[broker.tls]
+enabled = true
+verify = true
+
+[broker.auth]
+method = "token"
+audience = "mqtt-us-v1.letsmesh.net"
+
+[[broker]]
+name = "letsmesh-eu"
+enabled = true
+server = "mqtt-eu-v1.letsmesh.net"
+port = 443
+transport = "websockets"
+keepalive = 60
+qos = 0
+retain = true
+
+[broker.tls]
+enabled = true
+verify = true
+
+[broker.auth]
+method = "token"
+audience = "mqtt-eu-v1.letsmesh.net"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [project]
 name = "meshcoretomqtt"
-version = "1.2.0.0-preview"
+version = "1.3.0.0-preview"
 requires-python = ">=3.11"
 dependencies = [
+    "ed25519_orlp",
     "paho-mqtt",
     "tomli",
     "pyserial",

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -12,16 +12,20 @@ EXTRA_ARGS=()
 # Try to read repo/branch from existing config
 INSTALL_DIR="${MCTOMQTT_INSTALL_DIR:-/opt/mctomqtt}"
 CONFIG_DIR="${MCTOMQTT_CONFIG_DIR:-/etc/mctomqtt}"
-if [ -f "$CONFIG_DIR/config.d/00-user.toml" ]; then
+USER_TOML="$CONFIG_DIR/config.d/99-user.toml"
+if [ ! -f "$USER_TOML" ] && [ -f "$CONFIG_DIR/config.d/00-user.toml" ]; then
+    USER_TOML="$CONFIG_DIR/config.d/00-user.toml"
+fi
+if [ -f "$USER_TOML" ]; then
     _repo=$(python3 -c "
 import tomllib
-with open('$CONFIG_DIR/config.d/00-user.toml', 'rb') as f:
+with open('$USER_TOML', 'rb') as f:
     c = tomllib.load(f)
 print(c.get('update', {}).get('repo', ''))
 " 2>/dev/null || true)
     _branch=$(python3 -c "
 import tomllib
-with open('$CONFIG_DIR/config.d/00-user.toml', 'rb') as f:
+with open('$USER_TOML', 'rb') as f:
     c = tomllib.load(f)
 print(c.get('update', {}).get('branch', ''))
 " 2>/dev/null || true)

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from config_loader import merge_broker_lists
 from installer.config import (
@@ -16,8 +19,21 @@ from installer.config import (
     append_disabled_broker_toml,
     append_letsmesh_broker_toml,
     append_remote_serial_toml,
+    append_token_owner_overrides_toml,
+    configured_presets,
+    copy_preset_to_config,
+    import_preset_to_config,
+    list_bundled_presets,
+    migrate_user_config_filename,
+    preset_dest_path,
+    _manage_existing_presets,
+    token_broker_names_from_preset,
+    validate_preset_toml,
     write_user_toml_base,
 )
+
+
+PROJECT_ROOT = Path(__file__).parent.parent
 
 
 class TestWriteUserTomlBase:
@@ -242,6 +258,159 @@ class TestAppendRemoteSerialToml:
 
         assert data["remote_serial"]["enabled"] is False
         assert data["remote_serial"]["allowed_companions"] == []
+
+
+class TestUserConfigMigration:
+    def test_renames_legacy_user_config(self, tmp_path: Path) -> None:
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        legacy = config_d / "00-user.toml"
+        legacy.write_text('[general]\niata = "SEA"\n')
+
+        result = migrate_user_config_filename(tmp_path)
+
+        assert result == config_d / "99-user.toml"
+        assert result.read_text() == '[general]\niata = "SEA"\n'
+        assert not legacy.exists()
+
+    def test_conflict_aborts_when_both_user_configs_exist(self, tmp_path: Path) -> None:
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        (config_d / "00-user.toml").write_text('[general]\niata = "SEA"\n')
+        (config_d / "99-user.toml").write_text('[general]\niata = "LAX"\n')
+
+        with pytest.raises(SystemExit):
+            migrate_user_config_filename(tmp_path)
+
+
+class TestPresetFiles:
+    def test_preset_dest_path_prefixes_filename(self, tmp_path: Path) -> None:
+        assert preset_dest_path(tmp_path, "letsmesh.toml") == tmp_path / "config.d" / "10-letsmesh.toml"
+
+    def test_letsmesh_preset_is_first_bundled_default(self) -> None:
+        presets = list_bundled_presets(PROJECT_ROOT)
+        names = [preset.name for preset in presets]
+
+        assert "letsmesh.toml" in names
+        assert names.index("letsmesh.toml") == 0
+
+    def test_validate_valid_preset(self, tmp_path: Path) -> None:
+        preset = tmp_path / "letsmesh.toml"
+        preset.write_text('[[broker]]\nname = "letsmesh-us"\nserver = "mqtt.example"\n')
+
+        data = validate_preset_toml(preset)
+
+        assert data["broker"][0]["name"] == "letsmesh-us"
+
+    def test_rejects_preset_without_broker(self, tmp_path: Path) -> None:
+        preset = tmp_path / "empty.toml"
+        preset.write_text("[general]\niata = \"SEA\"\n")
+
+        with pytest.raises(ValueError):
+            validate_preset_toml(preset)
+
+    def test_rejects_preset_without_broker_name(self, tmp_path: Path) -> None:
+        preset = tmp_path / "bad.toml"
+        preset.write_text('[[broker]]\nserver = "mqtt.example"\n')
+
+        with pytest.raises(ValueError):
+            validate_preset_toml(preset)
+
+    def test_rejects_invalid_toml(self, tmp_path: Path) -> None:
+        preset = tmp_path / "bad.toml"
+        preset.write_text("[[broker]\n")
+
+        with pytest.raises(tomllib.TOMLDecodeError):
+            validate_preset_toml(preset)
+
+    def test_rejects_unsafe_filename(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            preset_dest_path(tmp_path, "../evil.toml")
+
+    def test_copy_preset_uses_prefixed_name(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "etc"
+        source = tmp_path / "letsmesh.toml"
+        source.write_text('[[broker]]\nname = "letsmesh-us"\n')
+
+        copied = copy_preset_to_config(source, config_dir)
+
+        assert copied == config_dir / "config.d" / "10-letsmesh.toml"
+        with open(copied, "rb") as f:
+            data = tomllib.load(f)
+        assert data["broker"][0]["name"] == "letsmesh-us"
+
+    def test_import_local_preset(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "etc"
+        source = tmp_path / "community.toml"
+        source.write_text('[[broker]]\nname = "community"\n')
+
+        copied = import_preset_to_config(str(source), config_dir)
+
+        assert copied == config_dir / "config.d" / "10-community.toml"
+        assert copied.exists()
+
+    def test_token_broker_names_from_preset(self, tmp_path: Path) -> None:
+        preset = tmp_path / "token.toml"
+        preset.write_text(
+            '[[broker]]\nname = "token-broker"\n[broker.auth]\nmethod = "token"\n'
+            '\n[[broker]]\nname = "anon"\n[broker.auth]\nmethod = "none"\n'
+        )
+
+        assert token_broker_names_from_preset(preset) == [("token.toml", "token-broker")]
+
+    def test_configured_presets_lists_active_preset_brokers(self, tmp_path: Path) -> None:
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        (config_d / "10-letsmesh.toml").write_text(
+            '[[broker]]\nname = "letsmesh-us"\n'
+            '\n[[broker]]\nname = "letsmesh-eu"\n'
+        )
+
+        result = configured_presets(tmp_path)
+
+        assert result[config_d / "10-letsmesh.toml"] == ["letsmesh-us", "letsmesh-eu"]
+
+    def test_manage_existing_presets_deletes_file_and_matching_overrides(self, tmp_path: Path) -> None:
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        preset = config_d / "10-letsmesh.toml"
+        preset.write_text(
+            '[[broker]]\nname = "letsmesh-us"\n'
+            '\n[[broker]]\nname = "letsmesh-eu"\n'
+        )
+        user_toml = config_d / "99-user.toml"
+        user_toml.write_text(
+            '[general]\niata = "SEA"\n\n'
+            '[[broker]]\nname = "letsmesh-us"\n[broker.auth]\nowner = "OWNER"\n'
+            '\n[[broker]]\nname = "custom-override"\nserver = "mqtt.example.com"\n'
+        )
+
+        with (
+            patch("installer.config.prompt_input", return_value="1"),
+            patch("installer.config.prompt_yes_no", return_value=True),
+        ):
+            _manage_existing_presets(str(tmp_path))
+
+        content = user_toml.read_text()
+        assert not preset.exists()
+        assert 'name = "letsmesh-us"' not in content
+        assert 'name = "custom-override"' in content
+        assert 'server = "mqtt.example.com"' in content
+
+
+class TestAppendTokenOwnerOverridesToml:
+    def test_appends_valid_owner_overrides(self, tmp_path: Path) -> None:
+        dest = str(tmp_path / "99-user.toml")
+        write_user_toml_base(dest, "SEA", "/dev/ttyACM0", "repo", "main")
+        append_token_owner_overrides_toml(dest, ["letsmesh-us"], "OWNER123", "test@example.com")
+
+        with open(dest, "rb") as f:
+            data = tomllib.load(f)
+
+        broker = data["broker"][0]
+        assert broker["name"] == "letsmesh-us"
+        assert broker["auth"]["owner"] == "OWNER123"
+        assert broker["auth"]["email"] == "test@example.com"
 
 
 class TestReadExistingIata:

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -14,6 +14,10 @@ import pytest
 from config_loader import merge_broker_lists
 from installer.config import (
     _read_existing_iata,
+    _read_remote_serial_companions,
+    _rewrite_token_owner_overrides_toml,
+    _set_remote_serial,
+    _toml_dumps,
     _update_iata_in_file,
     append_custom_broker_toml,
     append_disabled_broker_toml,
@@ -491,3 +495,228 @@ class TestFullComposition:
         # Remote serial
         assert data["remote_serial"]["enabled"] is True
         assert data["remote_serial"]["allowed_companions"] == ["KEY1", "KEY2"]
+
+
+class TestTomlDumpsRoundTrip:
+    """The generic TOML serializer must preserve any structure tomllib can parse."""
+
+    def _roundtrip(self, source: str) -> dict:
+        original = tomllib.loads(source)
+        rendered = _toml_dumps(original)
+        return tomllib.loads(rendered)
+
+    def test_preserves_unknown_top_level_section(self) -> None:
+        """A user's [topics] override must survive a load/modify/dump cycle."""
+        source = (
+            '[general]\niata = "SEA"\n\n'
+            '[topics]\nstatus = "custom/{IATA}/status"\npackets = "custom/{IATA}/packets"\n'
+        )
+        result = self._roundtrip(source)
+        assert result["topics"]["status"] == "custom/{IATA}/status"
+        assert result["topics"]["packets"] == "custom/{IATA}/packets"
+
+    def test_preserves_unknown_broker_subsection(self) -> None:
+        """Future broker subsections (e.g. [broker.metrics]) must round-trip."""
+        source = (
+            '[[broker]]\nname = "x"\n'
+            '[broker.metrics]\nenabled = true\ninterval = 30\n'
+        )
+        result = self._roundtrip(source)
+        assert result["broker"][0]["metrics"] == {"enabled": True, "interval": 30}
+
+    def test_preserves_arbitrary_nested_tables(self) -> None:
+        """Three-level nesting and deeply nested tables stay intact."""
+        source = '[a.b.c]\nkey = "value"\n[a.b.c.d]\nflag = false\n'
+        result = self._roundtrip(source)
+        assert result["a"]["b"]["c"]["key"] == "value"
+        assert result["a"]["b"]["c"]["d"]["flag"] is False
+
+    def test_preserves_value_types(self) -> None:
+        source = (
+            '[s]\n'
+            'a_str = "hello"\n'
+            'a_int = 42\n'
+            'a_neg = -7\n'
+            'a_float = 3.14\n'
+            'a_bool_t = true\n'
+            'a_bool_f = false\n'
+            'a_arr = [1, 2, 3]\n'
+            'a_str_arr = ["x", "y"]\n'
+        )
+        result = self._roundtrip(source)
+        assert result["s"]["a_str"] == "hello"
+        assert result["s"]["a_int"] == 42
+        assert result["s"]["a_neg"] == -7
+        assert result["s"]["a_float"] == 3.14
+        assert result["s"]["a_bool_t"] is True
+        assert result["s"]["a_bool_f"] is False
+        assert result["s"]["a_arr"] == [1, 2, 3]
+        assert result["s"]["a_str_arr"] == ["x", "y"]
+
+    def test_escapes_strings_with_special_characters(self) -> None:
+        source = '[s]\npath = "C:\\\\Users\\\\foo"\nquote = "she said \\"hi\\""\n'
+        result = self._roundtrip(source)
+        assert result["s"]["path"] == "C:\\Users\\foo"
+        assert result["s"]["quote"] == 'she said "hi"'
+
+    def test_preserves_array_of_tables_order(self) -> None:
+        source = (
+            '[[broker]]\nname = "first"\n\n'
+            '[[broker]]\nname = "second"\n\n'
+            '[[broker]]\nname = "third"\n'
+        )
+        result = self._roundtrip(source)
+        assert [b["name"] for b in result["broker"]] == ["first", "second", "third"]
+
+    def test_quotes_keys_that_are_not_bare(self) -> None:
+        data = {"general": {"weird key": "value"}}
+        rendered = _toml_dumps(data)
+        # Round-trip back through tomllib to confirm the quoting is valid
+        assert tomllib.loads(rendered)["general"]["weird key"] == "value"
+
+
+class TestRewriteTokenOwnerOverridesPreservesData:
+    """Issue #1 regression tests — the rewriter must not drop unknown sections."""
+
+    def test_preserves_topics_section(self, tmp_path: Path) -> None:
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text(
+            '[general]\niata = "SEA"\n\n'
+            '[topics]\nstatus = "custom/{IATA}/status"\n\n'
+            '[[broker]]\nname = "letsmesh-us"\n'
+        )
+
+        _rewrite_token_owner_overrides_toml(
+            str(user_toml), ["letsmesh-us"], "OWNER123", "owner@example.com"
+        )
+
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["topics"]["status"] == "custom/{IATA}/status"
+        assert data["broker"][0]["auth"]["owner"] == "OWNER123"
+
+    def test_preserves_unknown_broker_subsection(self, tmp_path: Path) -> None:
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text(
+            '[[broker]]\nname = "letsmesh-us"\n'
+            '[broker.metrics]\nenabled = true\n'
+        )
+
+        _rewrite_token_owner_overrides_toml(
+            str(user_toml), ["letsmesh-us"], "OWNER", ""
+        )
+
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["broker"][0]["metrics"] == {"enabled": True}
+        assert data["broker"][0]["auth"]["owner"] == "OWNER"
+
+    def test_preserves_other_top_level_scalars(self, tmp_path: Path) -> None:
+        """A future top-level [foo] section with arbitrary keys must round-trip."""
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text(
+            '[general]\niata = "SEA"\n\n'
+            '[future_feature]\nlevel = 5\nname = "experimental"\n\n'
+            '[[broker]]\nname = "letsmesh-us"\n'
+        )
+
+        _rewrite_token_owner_overrides_toml(
+            str(user_toml), ["letsmesh-us"], "OWNER", ""
+        )
+
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["future_feature"] == {"level": 5, "name": "experimental"}
+
+
+class TestSetRemoteSerial:
+    """Issue #2 regression tests — [remote_serial] mutations must be in-place, not appended."""
+
+    def test_creates_section_when_absent(self, tmp_path: Path) -> None:
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text('[general]\niata = "SEA"\n')
+
+        _set_remote_serial(str(user_toml), "KEY1,KEY2")
+
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["remote_serial"]["enabled"] is True
+        assert data["remote_serial"]["allowed_companions"] == ["KEY1", "KEY2"]
+
+    def test_replaces_existing_section_in_place(self, tmp_path: Path) -> None:
+        """Calling _set_remote_serial twice must NOT duplicate [remote_serial]."""
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text(
+            '[general]\niata = "SEA"\n\n'
+            '[remote_serial]\nenabled = true\nallowed_companions = ["OLD"]\n'
+        )
+
+        _set_remote_serial(str(user_toml), "NEW1,NEW2")
+
+        # File must be valid TOML (a duplicate [remote_serial] would raise here)
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["remote_serial"]["allowed_companions"] == ["NEW1", "NEW2"]
+        # Confirm the literal text only contains one [remote_serial] header
+        assert user_toml.read_text().count("[remote_serial]") == 1
+
+    def test_disables_when_companions_empty(self, tmp_path: Path) -> None:
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text(
+            '[remote_serial]\nenabled = true\nallowed_companions = ["KEY"]\n'
+        )
+
+        _set_remote_serial(str(user_toml), "")
+
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["remote_serial"]["enabled"] is False
+        assert data["remote_serial"]["allowed_companions"] == []
+
+    def test_repeated_calls_keep_file_valid(self, tmp_path: Path) -> None:
+        """Many successive sets must keep the file parseable and idempotent."""
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text('[general]\niata = "SEA"\n')
+
+        for csv in ("A,B", "C", "", "D,E,F", "D,E,F"):
+            _set_remote_serial(str(user_toml), csv)
+
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["remote_serial"]["allowed_companions"] == ["D", "E", "F"]
+        assert user_toml.read_text().count("[remote_serial]") == 1
+
+    def test_preserves_other_sections(self, tmp_path: Path) -> None:
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text(
+            '[general]\niata = "SEA"\n\n'
+            '[topics]\nstatus = "custom/{IATA}"\n\n'
+            '[[broker]]\nname = "custom"\nserver = "mqtt.example"\n'
+        )
+
+        _set_remote_serial(str(user_toml), "KEY1")
+
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["general"]["iata"] == "SEA"
+        assert data["topics"]["status"] == "custom/{IATA}"
+        assert data["broker"][0]["name"] == "custom"
+        assert data["remote_serial"]["allowed_companions"] == ["KEY1"]
+
+
+class TestReadRemoteSerialCompanions:
+    def test_returns_csv_of_existing_companions(self, tmp_path: Path) -> None:
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text(
+            '[remote_serial]\nenabled = true\nallowed_companions = ["A", "B", "C"]\n'
+        )
+        assert _read_remote_serial_companions(user_toml) == "A,B,C"
+
+    def test_empty_when_section_missing(self, tmp_path: Path) -> None:
+        user_toml = tmp_path / "99-user.toml"
+        user_toml.write_text('[general]\niata = "SEA"\n')
+        assert _read_remote_serial_companions(user_toml) == ""
+
+    def test_empty_when_file_missing(self, tmp_path: Path) -> None:
+        assert _read_remote_serial_companions(tmp_path / "missing.toml") == ""
+

--- a/tests/test_docker_config_mount.py
+++ b/tests/test_docker_config_mount.py
@@ -1,0 +1,46 @@
+"""Tests for Docker service command construction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from installer import InstallerContext
+from installer.system import install_docker_service
+
+
+def test_docker_service_mounts_config_directory(tmp_path: Path) -> None:
+    config_dir = tmp_path / "etc" / "mctomqtt"
+    config_d = config_dir / "config.d"
+    config_d.mkdir(parents=True)
+    (config_dir / "config.toml").write_text("[general]\n")
+    (config_d / "99-user.toml").write_text('[serial]\nports = ["/dev/ttyACM0"]\n')
+
+    ctx = InstallerContext(config_dir=str(config_dir), install_dir=str(tmp_path / "opt"))
+    run_calls: list[list[str]] = []
+
+    def fake_run_cmd(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        run_calls.append(cmd)
+        if cmd == ["docker", "--version"]:
+            return SimpleNamespace(returncode=0, stdout="Docker version test\n")
+        if cmd == ["docker", "ps", "-a"]:
+            return SimpleNamespace(returncode=0, stdout="")
+        return SimpleNamespace(returncode=0, stdout="")
+
+    with (
+        patch("installer.system.shutil.which", return_value="/usr/bin/docker"),
+        patch("installer.system.docker_cmd", return_value="docker"),
+        patch("installer.system.pull_or_build_docker_image", return_value="mctomqtt:test"),
+        patch("installer.system.prompt_yes_no", return_value=True),
+        patch("installer.system.run_cmd", side_effect=fake_run_cmd),
+        patch("installer.system.check_service_health"),
+        patch("installer.system.Path.exists", return_value=True),
+    ):
+        assert install_docker_service(ctx) is True
+
+    docker_run = next(call for call in run_calls if call[:2] == ["docker", "run"])
+    assert "-v" in docker_run
+    assert f"{config_dir}:/etc/mctomqtt:ro" in docker_run
+    assert not any("/config.toml:/etc/mctomqtt/config.toml" in part for part in docker_run)
+    assert not any("/config.d/" in part and ":/etc/mctomqtt/config.d/" in part for part in docker_run)

--- a/tests/test_migrate_flow.py
+++ b/tests/test_migrate_flow.py
@@ -73,7 +73,7 @@ class TestMigrateFlow:
         # Write to new location
         config_dir = tmp_path / "etc" / "mctomqtt" / "config.d"
         config_dir.mkdir(parents=True)
-        user_toml = config_dir / "00-user.toml"
+        user_toml = config_dir / "99-user.toml"
         user_toml.write_text(
             "# MeshCore to MQTT - User Configuration\n"
             "# Migrated from legacy .env/.env.local installation\n\n"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -24,7 +24,7 @@ class TestSetPermissions:
         config_d.mkdir()
         # Create test files
         (config_dir / "config.toml").write_text("[general]\n")
-        (config_d / "00-user.toml").write_text("[general]\niata = \"SEA\"\n")
+        (config_d / "99-user.toml").write_text("[general]\niata = \"SEA\"\n")
         return install_dir, config_dir
 
     def test_set_permissions_ownership(self, dirs: tuple[Path, Path]) -> None:

--- a/tests/test_update_flow.py
+++ b/tests/test_update_flow.py
@@ -19,22 +19,22 @@ PROJECT_ROOT = Path(__file__).parent.parent
 
 class TestUpdateFlow:
     def test_update_preserves_user_toml(self, tmp_path: Path) -> None:
-        """Verify that 00-user.toml is preserved after update."""
+        """Verify that 99-user.toml is preserved after update."""
         config_dir = tmp_path / "etc" / "mctomqtt"
         config_d = config_dir / "config.d"
         config_d.mkdir(parents=True)
 
-        # Create a 00-user.toml that should be preserved
+        # Create a 99-user.toml that should be preserved
         user_toml_content = '[general]\niata = "SEA"\n\n[serial]\nports = ["/dev/ttyACM0"]\n'
-        (config_d / "00-user.toml").write_text(user_toml_content)
+        (config_d / "99-user.toml").write_text(user_toml_content)
         (config_dir / "config.toml").write_text("[general]\niata = \"XXX\"\n")
 
-        # Simulate an update by verifying the 00-user.toml is intact
-        content = (config_d / "00-user.toml").read_text()
+        # Simulate an update by verifying the 99-user.toml is intact
+        content = (config_d / "99-user.toml").read_text()
         assert content == user_toml_content
 
         # Verify it's valid TOML
-        with open(config_d / "00-user.toml", "rb") as f:
+        with open(config_d / "99-user.toml", "rb") as f:
             data = tomllib.load(f)
         assert data["general"]["iata"] == "SEA"
         assert data["serial"]["ports"] == ["/dev/ttyACM0"]

--- a/tests/test_update_service_user.py
+++ b/tests/test_update_service_user.py
@@ -83,3 +83,53 @@ def test_update_detects_service_user_before_reconfigure(tmp_path: Path) -> None:
         "configure_mqtt_brokers:customsvc",
     ]
     assert ctx.svc_user == "customsvc"
+
+
+def test_update_reconfigure_preserves_user_toml(tmp_path: Path) -> None:
+    """Reconfigure must not delete existing custom broker overrides."""
+    repo_dir = tmp_path / "repo"
+    install_dir = tmp_path / "opt" / "mctomqtt"
+    config_dir = tmp_path / "etc" / "mctomqtt"
+    config_d = config_dir / "config.d"
+    work_dir = tmp_path / "work"
+    _write_repo_fixture(repo_dir)
+    install_dir.mkdir(parents=True)
+    config_d.mkdir(parents=True)
+    work_dir.mkdir()
+    (install_dir / "mctomqtt.py").write_text('__version__ = "old"\n')
+    user_toml = config_d / "99-user.toml"
+    content = (
+        '[general]\niata = "SEA"\n\n'
+        '[[broker]]\nname = "custom-override"\nserver = "mqtt.example.com"\n'
+    )
+    user_toml.write_text(content)
+
+    ctx = InstallerContext(
+        install_dir=str(install_dir),
+        config_dir=str(config_dir),
+        local_install=str(repo_dir),
+    )
+
+    def fake_configure_mqtt_brokers(_ctx: InstallerContext) -> None:
+        assert user_toml.exists()
+        assert user_toml.read_text() == content
+
+    with (
+        patch("installer.update_cmd.detect_system_type", return_value="manual"),
+        patch("installer.update_cmd.detect_service_user", return_value="customsvc"),
+        patch("installer.update_cmd.create_system_user"),
+        patch("installer.update_cmd.configure_mqtt_brokers", side_effect=fake_configure_mqtt_brokers),
+        patch("installer.update_cmd.create_venv"),
+        patch("installer.update_cmd.cleanup_legacy_nvm"),
+        patch("installer.update_cmd.set_permissions"),
+        patch("installer.update_cmd.create_version_info"),
+        patch("installer.update_cmd.prompt_yes_no", return_value=True),
+        patch(
+            "installer.update_cmd.run_cmd",
+            return_value=MagicMock(returncode=0, stdout="", stderr=""),
+        ),
+    ):
+        _do_update(ctx, str(work_dir))
+
+    assert user_toml.read_text() == content
+    assert list(config_d.glob("99-user.toml.backup-*"))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import urllib.error
 from unittest.mock import patch
 
+from pathlib import Path
+
+from installer import InstallerContext
 from installer.config import (
     _lookup_iata_code_with_retry,
     _configure_token_preset_overrides,
+    configure_mqtt_brokers,
     prompt_iata_letsmesh,
     validate_email,
     validate_meshcore_pubkey,
@@ -247,3 +251,125 @@ class TestTokenPresetOwnerPrompt:
         assert 'method = "none"' in content
         assert 'name = "letsmesh-us"' in content
         assert 'owner = "OWNER"' in content
+
+    def test_repeated_calls_do_not_duplicate_remote_serial(self, tmp_path) -> None:
+        """repeated invocations must not create a second [remote_serial] block."""
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        (config_d / "10-letsmesh.toml").write_text(
+            '[[broker]]\nname = "letsmesh-us"\n[broker.auth]\nmethod = "token"\n'
+        )
+        user_toml = config_d / "99-user.toml"
+        user_toml.write_text('[general]\niata = "SEA"\n')
+
+        with (
+            patch("installer.config.prompt_owner_pubkey", return_value="OWNER"),
+            patch("installer.config.prompt_owner_email", return_value="owner@example.com"),
+            patch("installer.config.prompt_yes_no", return_value=True),
+            patch("installer.config.prompt_input", side_effect=["", ""]),
+        ):
+            # First call: user provides no companion keys (empty input ends the loop)
+            _configure_token_preset_overrides(str(tmp_path))
+            # Second call: same again — must not append a duplicate section
+            _configure_token_preset_overrides(str(tmp_path))
+
+        # Must remain valid TOML (a duplicate [remote_serial] would raise here)
+        import tomllib
+        with open(user_toml, "rb") as f:
+            tomllib.load(f)
+        assert user_toml.read_text().count("[remote_serial]") <= 1
+
+    def test_existing_remote_serial_is_preserved_across_calls(self, tmp_path) -> None:
+        """pre-existing companions must be shown and re-used as the prompt default."""
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        (config_d / "10-letsmesh.toml").write_text(
+            '[[broker]]\nname = "letsmesh-us"\n[broker.auth]\nmethod = "token"\n'
+        )
+        user_toml = config_d / "99-user.toml"
+        user_toml.write_text(
+            '[general]\niata = "SEA"\n\n'
+            '[remote_serial]\nenabled = true\nallowed_companions = ["EXISTING"]\n'
+        )
+
+        captured: dict = {}
+
+        def fake_prompt_companions(existing: str = "") -> str:
+            captured["existing"] = existing
+            return existing  # user keeps existing
+
+        with (
+            patch("installer.config.prompt_yes_no", return_value=False),  # decline owner change
+            patch("installer.config.prompt_owner_pubkey", return_value=""),
+            patch("installer.config.prompt_owner_email", return_value=""),
+            patch("installer.config.prompt_allowed_companions", side_effect=fake_prompt_companions),
+        ):
+            _configure_token_preset_overrides(str(tmp_path))
+
+        # The prompt must have been called with the existing CSV
+        assert captured["existing"] == "EXISTING"
+        # And the file must still have exactly one [remote_serial] section
+        import tomllib
+        with open(user_toml, "rb") as f:
+            data = tomllib.load(f)
+        assert data["remote_serial"]["allowed_companions"] == ["EXISTING"]
+        assert user_toml.read_text().count("[remote_serial]") == 1
+
+
+class TestConfigureMqttBrokersIataPrompt:
+    """IATA must be prompted whenever any preset is configured."""
+
+    def _stub_ctx(self, config_dir: Path) -> InstallerContext:
+        return InstallerContext(
+            config_dir=str(config_dir),
+            install_dir=str(config_dir.parent / "opt"),
+            svc_user="",  # skip the chown branch
+        )
+
+    def test_iata_prompted_for_non_token_preset(self, tmp_path: Path) -> None:
+        """Previously the IATA prompt only fired for token-auth presets."""
+        config_dir = tmp_path / "etc" / "mctomqtt"
+        config_d = config_dir / "config.d"
+        config_d.mkdir(parents=True)
+        (config_d / "10-anon.toml").write_text(
+            '[[broker]]\nname = "anon"\nserver = "mqtt.example.com"\n'
+            '[broker.auth]\nmethod = "none"\n'
+        )
+        (config_d / "99-user.toml").write_text('[general]\niata = "XXX"\n')
+
+        ctx = self._stub_ctx(config_dir)
+
+        with (
+            patch("installer.config.prompt_input", return_value="5"),  # finish loop
+            patch("installer.config.prompt_yes_no", return_value=False),
+            patch("installer.config.prompt_iata_letsmesh", return_value="SEA") as mock_iata,
+            patch("installer.config.platform.system", return_value="Darwin"),
+        ):
+            configure_mqtt_brokers(ctx)
+
+        mock_iata.assert_called_once()
+        import tomllib
+        with open(config_d / "99-user.toml", "rb") as f:
+            data = tomllib.load(f)
+        assert data["general"]["iata"] == "SEA"
+
+    def test_no_iata_prompt_when_no_presets(self, tmp_path: Path) -> None:
+        """If the user finishes without adding any preset, don't prompt for IATA."""
+        config_dir = tmp_path / "etc" / "mctomqtt"
+        config_d = config_dir / "config.d"
+        config_d.mkdir(parents=True)
+        (config_d / "99-user.toml").write_text('[general]\niata = "XXX"\n')
+
+        ctx = self._stub_ctx(config_dir)
+
+        with (
+            patch("installer.config.prompt_input", return_value="5"),
+            patch("installer.config.prompt_yes_no", return_value=False),
+            patch("installer.config.prompt_iata_letsmesh") as mock_iata,
+            patch("installer.config.prompt_iata_simple") as mock_iata_simple,
+            patch("installer.config.platform.system", return_value="Darwin"),
+        ):
+            configure_mqtt_brokers(ctx)
+
+        mock_iata.assert_not_called()
+        mock_iata_simple.assert_not_called()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from installer.config import validate_email, validate_meshcore_pubkey
+import urllib.error
+from unittest.mock import patch
+
+from installer.config import (
+    _lookup_iata_code_with_retry,
+    _configure_token_preset_overrides,
+    prompt_iata_letsmesh,
+    validate_email,
+    validate_meshcore_pubkey,
+)
 
 
 class TestValidateMeshcorePubkey:
@@ -96,3 +105,145 @@ class TestValidateEmail:
 
     def test_no_dot_in_domain_returns_none(self) -> None:
         assert validate_email("a@bc") is None
+
+
+class TestPromptIataLetsmesh:
+    def test_direct_code_can_be_used_when_lookup_misses(self) -> None:
+        with (
+            patch("installer.config.prompt_input", return_value="SEA"),
+            patch("installer.config._lookup_iata_code_with_retry", return_value=(None, False)),
+            patch("installer.config.prompt_yes_no", return_value=True),
+        ):
+            assert prompt_iata_letsmesh(script_version="test") == "SEA"
+
+    def test_direct_code_can_be_used_when_validation_unavailable(self) -> None:
+        with (
+            patch("installer.config.prompt_input", return_value="SEA"),
+            patch("installer.config._lookup_iata_code_with_retry", return_value=(None, True)),
+            patch("installer.config.prompt_yes_no", return_value=True),
+        ):
+            assert prompt_iata_letsmesh(script_version="test") == "SEA"
+
+
+class TestLookupIataCodeWithRetry:
+    def test_retries_transient_failure_then_succeeds(self) -> None:
+        with (
+            patch(
+                "installer.config._iata_request",
+                side_effect=[urllib.error.URLError("temporary"), b'{"name": "Seattle-Tacoma"}'],
+            ),
+            patch("installer.config.time.sleep"),
+        ):
+            assert _lookup_iata_code_with_retry("SEA", attempts=2) == ("Seattle-Tacoma", False)
+
+    def test_reports_validation_unavailable_after_retries(self) -> None:
+        with (
+            patch("installer.config._iata_request", side_effect=urllib.error.URLError("temporary")),
+            patch("installer.config.time.sleep"),
+        ):
+            assert _lookup_iata_code_with_retry("SEA", attempts=2) == (None, True)
+
+
+class TestTokenPresetOwnerPrompt:
+    def test_shows_preset_and_current_owner_info(self, tmp_path) -> None:
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        preset = config_d / "10-letsmesh.toml"
+        preset.write_text(
+            '[[broker]]\nname = "letsmesh-us"\n[broker.auth]\nmethod = "token"\n'
+            '\n[[broker]]\nname = "letsmesh-eu"\n[broker.auth]\nmethod = "token"\n'
+        )
+        user_toml = config_d / "99-user.toml"
+        user_toml.write_text('[general]\niata = "SEA"\n')
+
+        with (
+            patch("installer.config.prompt_owner_pubkey", return_value=""),
+            patch("installer.config.prompt_owner_email", return_value=""),
+            patch("installer.config.prompt_allowed_companions", return_value=""),
+            patch("builtins.print") as mock_print,
+        ):
+            _configure_token_preset_overrides(str(tmp_path))
+
+        printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list if call.args)
+        assert "Owner Info: 10-letsmesh.toml" in printed
+        assert "letsmesh-us" in printed
+        assert "letsmesh-eu" in printed
+        assert "owner: (not set)" in printed
+
+    def test_existing_owner_info_can_be_kept(self, tmp_path) -> None:
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        preset = config_d / "10-community.toml"
+        preset.write_text(
+            '[[broker]]\nname = "community"\n[broker.auth]\nmethod = "token"\n'
+            'owner = "OLDOWNER"\nemail = "old@example.com"\n'
+        )
+        user_toml = config_d / "99-user.toml"
+        user_toml.write_text('[general]\niata = "SEA"\n')
+
+        with (
+            patch("installer.config.prompt_yes_no", return_value=False) as mock_yes_no,
+            patch("installer.config.prompt_owner_pubkey") as mock_owner,
+            patch("installer.config.prompt_owner_email") as mock_email,
+            patch("installer.config.prompt_allowed_companions", return_value=""),
+        ):
+            _configure_token_preset_overrides(str(tmp_path))
+
+        mock_yes_no.assert_called_once()
+        mock_owner.assert_not_called()
+        mock_email.assert_not_called()
+
+    def test_presets_can_get_different_owner_info(self, tmp_path) -> None:
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        (config_d / "10-a.toml").write_text(
+            '[[broker]]\nname = "a"\n[broker.auth]\nmethod = "token"\n'
+        )
+        (config_d / "10-b.toml").write_text(
+            '[[broker]]\nname = "b"\n[broker.auth]\nmethod = "token"\n'
+        )
+        user_toml = config_d / "99-user.toml"
+        user_toml.write_text('[general]\niata = "SEA"\n')
+
+        with (
+            patch("installer.config.prompt_owner_pubkey", side_effect=["OWNERA", "OWNERB"]),
+            patch("installer.config.prompt_owner_email", side_effect=["a@example.com", "b@example.com"]),
+            patch("installer.config.prompt_allowed_companions", return_value=""),
+        ):
+            _configure_token_preset_overrides(str(tmp_path))
+
+        content = user_toml.read_text()
+        assert 'name = "a"' in content
+        assert 'owner = "OWNERA"' in content
+        assert 'email = "a@example.com"' in content
+        assert 'name = "b"' in content
+        assert 'owner = "OWNERB"' in content
+        assert 'email = "b@example.com"' in content
+
+    def test_owner_info_update_preserves_custom_broker_overrides(self, tmp_path) -> None:
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        (config_d / "10-letsmesh.toml").write_text(
+            '[[broker]]\nname = "letsmesh-us"\n[broker.auth]\nmethod = "token"\n'
+        )
+        user_toml = config_d / "99-user.toml"
+        user_toml.write_text(
+            '[general]\niata = "SEA"\n\n'
+            '[[broker]]\nname = "custom-override"\nserver = "mqtt.example.com"\n'
+            'port = 1883\n[broker.auth]\nmethod = "none"\n'
+        )
+
+        with (
+            patch("installer.config.prompt_owner_pubkey", return_value="OWNER"),
+            patch("installer.config.prompt_owner_email", return_value="owner@example.com"),
+            patch("installer.config.prompt_allowed_companions", return_value=""),
+        ):
+            _configure_token_preset_overrides(str(tmp_path))
+
+        content = user_toml.read_text()
+        assert 'name = "custom-override"' in content
+        assert 'server = "mqtt.example.com"' in content
+        assert 'port = 1883' in content
+        assert 'method = "none"' in content
+        assert 'name = "letsmesh-us"' in content
+        assert 'owner = "OWNER"' in content

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -202,14 +202,17 @@ remove_service_user() {
 # Remove configuration files
 remove_config() {
     local config_dir="$DEFAULT_CONFIG_DIR"
-    local user_toml="$config_dir/config.d/00-user.toml"
+    local user_toml="$config_dir/config.d/99-user.toml"
+    if [ ! -f "$user_toml" ] && [ -f "$config_dir/config.d/00-user.toml" ]; then
+        user_toml="$config_dir/config.d/00-user.toml"
+    fi
 
     if [ ! -d "$config_dir" ]; then
         print_info "No configuration directory found at $config_dir"
         return
     fi
 
-    # Offer to back up 00-user.toml before removal
+    # Offer to back up the user TOML before removal
     if [ -f "$user_toml" ]; then
         echo "Your user configuration file:"
         echo ""
@@ -219,7 +222,7 @@ remove_config() {
         fi
         echo ""
 
-        if prompt_yes_no "Do you want to back up 00-user.toml before uninstalling?" "y"; then
+        if prompt_yes_no "Do you want to back up $(basename "$user_toml") before uninstalling?" "y"; then
             BACKUP_FILE="$HOME/mctomqtt-user-toml-backup-$(date +%Y%m%d-%H%M%S).toml"
             sudo cp "$user_toml" "$BACKUP_FILE"
             sudo chown "$(whoami)" "$BACKUP_FILE"


### PR DESCRIPTION
During install or update, the user is prompted if they want to install a preset. This commit includes one preset, LetsMesh, but the community may contribute any number.

This change moves the user.toml from a 00- prefix to a 99- prefix so its loaded after most configs, allowing overrides such as owner info for brokers to be added in this file instead of in the static presets.

The behavior of "just press enter and you'll be set up on LetsMesh" was preserved.