### PR TITLE
add chimesh broker preset for ChicagolandMesh.org

### DIFF
--- a/presets/chimesh.toml
+++ b/presets/chimesh.toml
@@ -1,0 +1,19 @@
+# ChicagolandMesh.org broker preset
+
+[[broker]]
+name = "chimesh"
+enabled = true
+server = "mqtt.chimesh.org"
+port = 443
+transport = "websockets"
+keepalive = 60
+qos = 0
+retain = true
+
+[broker.tls]
+enabled = true
+verify = true
+
+[broker.auth]
+method = "token"
+audience = "mqtt.chimesh.org"


### PR DESCRIPTION
This PR adds a custom broker named `chimesh` for the [ChicagolandMesh.org](https://chimesh.org) community.