### PR TITLE
Create and update meshat-se.toml preset

### DIFF
--- a/presets/meshat-se.toml
+++ b/presets/meshat-se.toml
@@ -1,6 +1,7 @@
 # Preset for the Swedish broker on Meshat.se
+
 [[broker]]
-name = "meshat.se"
+name = "Meshat.se"
 enabled = true
 server = "mqtt.meshat.se"
 port = 8883

--- a/presets/meshat-se.toml
+++ b/presets/meshat-se.toml
@@ -1,0 +1,14 @@
+# Preset for the Swedish broker on Meshat.se
+[[broker]]
+name = "meshat.se"
+enabled = true
+server = "mqtt.meshat.se"
+port = 8883
+
+[broker.auth]
+method = "password"
+username = "msh"
+password = "msh"
+
+[broker.tls]
+enabled = true


### PR DESCRIPTION
Meshat.se is a website focused on Mesh in Sweden. It also includes a mqtt broker to see the Swedish mesh, with MeshCore maps pointed at it.

Hopefully this preset can be added!

All the best!
/Jesper