### PR TITLE
Add Waev broker preset

### DIFF
--- a/presets/waev.toml
+++ b/presets/waev.toml
@@ -1,0 +1,37 @@
+# Waev: real-time telemetry, monitoring, and analytics for MeshCore radio networks. Understand traffic. Monitor performance. Optimize your mesh. Built primarily for advanced pyMC users, but can benefit any user using mqtt capable firmware. Waev is built with a trust-but-verify philosophy, using meshcores most observable signals while valueing and protecting personally identifiable companion signals.
+
+[[broker]]
+name = "waev-a"
+enabled = true
+server = "mqtt-a.waev.app"
+port = 443
+transport = "websockets"
+keepalive = 60
+qos = 0
+retain = true
+
+[broker.tls]
+enabled = true
+verify = true
+
+[broker.auth]
+method = "token"
+audience = "mqtt-a.waev.app"
+
+[[broker]]
+name = "waev-b"
+enabled = true
+server = "mqtt-b.waev.app"
+port = 443
+transport = "websockets"
+keepalive = 60
+qos = 0
+retain = true
+
+[broker.tls]
+enabled = true
+verify = true
+
+[broker.auth]
+method = "token"
+audience = "mqtt-b.waev.app"


### PR DESCRIPTION
## Summary
Adds `presets/waev.toml` so installers can pick **Waev** from the bundled-preset menu introduced in #51.

[Waev](https://waev.app) provides real-time telemetry, mapping, and analytics for MeshCore networks. It runs two independent brokers (`mqtt-a.waev.app` and `mqtt-b.waev.app`) in active-active configuration, accepting MQTT-over-WebSockets on port 443 with Ed25519 JWT auth — the same scheme as the existing LetsMesh preset.

## What's in the preset
Two `[[broker]]` blocks, one per regional endpoint, each with:

- `transport = "websockets"`, `port = 443`
- `[broker.tls]` enabled with `verify = true`
- `[broker.auth] method = "token"` with `audience` set to the broker hostname
- `keepalive = 60`, `qos = 0`, `retain = true` (mirrors `letsmesh.toml`)

The file deliberately omits user-specific fields (`owner`, `email`, `iata`, serial settings) — per the design introduced in #51 those are written to `99-user.toml` by the installer's prompt flow when a token preset is selected.

## Validation
Validated locally using the same checks the installer runs:

```
$ python3 -c 'import tomllib; tomllib.load(open("presets/waev.toml","rb"))'
$ python3 -c 'from installer.config import validate_preset_toml; validate_preset_toml("presets/waev.toml")'
```

Both pass. PR CI (`pr-tests.yaml`) will rerun the full test suite.

## Compatibility check vs. Waev's broker
Cross-checked the preset against Waev's broker source (a Mochi MQTT server fronted by Cloudflare Containers):

- WebSocket upgrade at `/` with subprotocol `mqtt` — matches paho-mqtt's default and `bridge/broker_client.py`'s `ws_set_options(path="/")`.
- JWT format (`{"alg":"Ed25519","typ":"JWT"}` header, `{publicKey, aud, iat, exp, email, owner}` payload, hex Ed25519 signature, username `v1_{PUBLIC_KEY_HEX}`) matches what `auth_token.py` produces under `method = "token"` exactly.
- Required topic format `meshcore/{IATA}/{PUBLIC_KEY}/{subtopic}` matches the meshcoretomqtt defaults — no `[broker.topics]` override needed.

## Notes for users
After installing this preset, the installer's standard token-preset flow will prompt for the optional `owner` (companion node pubkey) and `email`. Setting `email` to your Waev account address is what links observers to your account so they appear in Outpost.
