### PR TITLE
Add ColoradoMesh broker preset

### DIFF
--- a/presets/coloradomesh.toml
+++ b/presets/coloradomesh.toml
@@ -1,0 +1,19 @@
+# ColoradoMesh.org broker preset
+
+[[broker]]
+name = "coloradomesh"
+enabled = true
+server = "mqtt.meshcore.coloradomesh.org"
+port = 1883
+transport = "websockets"
+keepalive = 60
+qos = 0
+retain = true
+
+[broker.tls]
+enabled = true
+verify = true
+
+[broker.auth]
+method = "token"
+audience = "mqtt.meshcore.coloradomesh.org"


### PR DESCRIPTION
Adds a custom broker preset named `coloradomesh` for the [Colorado Mesh](https://coloradomesh.org/) community.