### PR TITLE
fix: emit timezone-aware UTC timestamps in MQTT payloads

### DIFF
--- a/bridge/message_parser.py
+++ b/bridge/message_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from . import topics
@@ -34,7 +34,7 @@ def parse_and_publish(state: BridgeState, line: str) -> None:
     message: dict = {
         "origin": state.repeater_name,
         "origin_id": state.repeater_pub_key,
-        "timestamp": datetime.now().isoformat()
+        "timestamp": datetime.now(timezone.utc).isoformat()
     }
 
     # Handle RAW messages

--- a/bridge/mqtt_publish.py
+++ b/bridge/mqtt_publish.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, TYPE_CHECKING
 
 from . import topics
@@ -69,7 +69,7 @@ def build_status_message(state: BridgeState, status: str, include_stats: bool = 
     """Build a status message with all required fields."""
     message: dict[str, Any] = {
         "status": status,
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "origin": state.repeater_name,
         "origin_id": state.repeater_pub_key,
         "radio": state.radio_info if state.radio_info else "unknown",


### PR DESCRIPTION
Change `datetime.now().isoformat()` to `datetime.now(timezone.utc).isoformat()` in message_parser.py and mqtt_publish.py so all MQTT payloads carry an explicit UTC offset (+00:00). Fix removes the "Naive observer clock" warning introduced in CoreScope PR Kpa-clawbot/CoreScope#1480.

Before: "2026-06-05T12:00:00.123456"        (naive, no timezone)
After:  "2026-06-05T12:00:00.123456+00:00"  (timezone-aware UTC)

## Ecosystem alignment

This aligns the format across the MeshCore MQTT ecosystem:

| Producer                    | Timestamp format  |
|-----------------------------|-------------------|
| pyMC_Repeater (status/raw)  | +00:00 ISO        |
| meshcore-ha (status/packet) | naive ISO (PR https://github.com/meshcore-dev/meshcore-ha/pull/259) |
| meshcoretomqtt       | naive ISO (this PR)     |
| meshcore-packet-capture     | naive ISO (PR: ) |
