### PR TITLE
Update MQTT server and audience to meshmapper.net

### DIFF
--- a/presets/meshmapper.toml
+++ b/presets/meshmapper.toml
@@ -3,7 +3,7 @@
 [[broker]]
 name = "meshmapper"
 enabled = true
-server = "mqtt.meshmapper.cc"
+server = "mqtt.meshmapper.net"
 port = 443
 transport = "websockets"
 keepalive = 60
@@ -16,4 +16,4 @@ verify = true
 
 [broker.auth]
 method = "token"
-audience = "mqtt.meshmapper.cc"
+audience = "mqtt.meshmapper.net"


### PR DESCRIPTION
Updates from the old domain of mqtt.meshmapper.cc to mqtt.meshmapper.net as requested by developer MrAlderson. See picture below taken from announcements on Meshmapper discord:

<img width="1267" height="178" alt="image" src="https://github.com/user-attachments/assets/1a6ee0af-13a1-46ae-b13a-3241927a9869" />
