### PR TITLE
Fix nix

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -50,8 +50,7 @@
       propagatedBuildInputs = with pkgs.python313Packages; [
         paho-mqtt
         pyserial
-        ed25519-orlp
-      ];
+      ] ++ [ ed25519-orlp ];  # reference the local variable outside the `with` scope
 
       nativeBuildInputs = [
         pkgs.makeWrapper

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -50,8 +50,7 @@
       propagatedBuildInputs = with pkgs.python313Packages; [
         paho-mqtt
         pyserial
-        ed25519-orlp
-      ];
+      ] ++ [ ed25519-orlp ];  # reference the local variable outside the `with` scope
 
       nativeBuildInputs = [
         pkgs.makeWrapper
@@ -74,7 +73,7 @@
         mkdir -p $out/bin
         makeWrapper ${pkgs.python313.interpreter} $out/bin/mctomqtt \
           --add-flags "$out/${pkgs.python313.sitePackages}/mctomqtt.py" \
-          --set PYTHONPATH "$out/${pkgs.python313.sitePackages}:${pkgs.python313.withPackages (ps: with ps; [paho-mqtt pyserial ed25519-orlp])}/${pkgs.python313.sitePackages}"
+          --set PYTHONPATH "$out/${pkgs.python313.sitePackages}:${pkgs.python313.withPackages (ps: with ps; [paho-mqtt pyserial])}/${pkgs.python313.sitePackages}:${ed25519-orlp}/${pkgs.python313.sitePackages}"
       '';
 
       meta = {


### PR DESCRIPTION
### Description
PR #50 introduced a regression where the `ed25519-orlp` dependency was not correctly included in the Nix build.

The variable `ed25519-orlp` was defined locally in a `let` block but referenced inside a `with pkgs.python313Packages;` expression. The `with` statement shadowed the local variable, causing Nix to look for the package in `python313Packages` where it doesn't exist.

This resulted in a runtime error:
```ModuleNotFoundError: No module named 'ed25519_orlp'```

### The Fix
This PR separates the local variable reference from the `with` scope using list concatenation (`++`), ensuring the correct local package is used in both:
1. `propagatedBuildInputs`
2. The `makeWrapper` PYTHONPATH in `installPhase`

### Testing
Verified that the service starts successfully and the module is found at runtime.