### PR TITLE
Update Colorado Mesh preset

### DIFF
--- a/presets/coloradomesh.toml
+++ b/presets/coloradomesh.toml
@@ -4,7 +4,7 @@
 name = "coloradomesh"
 enabled = true
 server = "mqtt.meshcore.coloradomesh.org"
-port = 1883
+port = 443
 transport = "websockets"
 keepalive = 60
 qos = 0


### PR DESCRIPTION
Ref: https://github.com/agessaman/meshcore-packet-capture/pull/44

Colorado Mesh finally updated their connection details to follow standard wss + 443 combination (legacy wss + 1883 still works)